### PR TITLE
docs: Codex CLI and session tracing research

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -167,6 +167,65 @@
 
 ---
 
+## Milestone 9: Claude Code Agent & Skill Discovery
+
+> Extend static discovery to find Claude Code agents from `.claude/agents/` (project and global).
+
+| # | Task | Details |
+|---|---|---|
+| 9.1 | Scan `.claude/agents/` in workspace root | Project-level Claude agents (priority 2 in Claude's resolution order) |
+| 9.2 | Scan `~/.claude/agents/` | Global user-level Claude agents (priority 3) |
+| 9.3 | Parse Claude agent markdown files | Same frontmatter + body format as Copilot agents, reuse existing parser |
+| 9.4 | Distinguish Claude vs Copilot agents | Badge or color in sidebar tree and Agent Graph |
+| 9.5 | Unit tests | Fixture-based tests for discovery and parsing of `.claude/agents/` files |
+
+**Issue:** [#10](https://github.com/23min/agent-lens/issues/10)
+**Branch:** `feature/claude-agent-discovery`
+**Definition of done:** Claude agents from `.claude/agents/` appear in sidebar tree and Agent Graph alongside Copilot agents.
+
+---
+
+## Milestone 10: OpenAI Codex CLI Support
+
+> Add Codex CLI as a third session provider. Parse rollout JSONL files from `~/.codex/sessions/`.
+
+| # | Task | Details |
+|---|---|---|
+| 9.1 | Research & format analysis | Document rollout JSONL structure, event types, token usage format (see `docs/research/codex-sessions.md`) |
+| 9.2 | Codex session locator | Discover `~/.codex/sessions/` (or `CODEX_HOME`). Walk `YYYY/MM/DD/rollout-*.jsonl` tree. |
+| 9.3 | Codex session parser | Parse rollout JSONL → `Session`/`SessionRequest` model. Extract token deltas from cumulative `token_count` events. |
+| 9.4 | Codex session provider | `CodexSessionProvider` wired into extension activation and refresh. |
+| 9.5 | `agentLens.codexDir` setting | Custom path override for non-default Codex home directories. |
+| 9.6 | Source filter: Codex | Add "Codex" to the All/Copilot/Claude toggle in Metrics Dashboard and Session Explorer. |
+| 9.7 | Provider badge | Codex badge in Session Explorer (green). |
+| 9.8 | Unit tests | Fixture-based tests for parser and locator. |
+
+**Issue:** [#13](https://github.com/23min/agent-lens/issues/13)
+**Branch:** `feature/codex-support`
+**Definition of done:** Codex sessions appear in Metrics Dashboard and Session Explorer alongside Copilot and Claude sessions.
+
+---
+
+## Milestone 11: Session Tracing & Execution Graphs
+
+> Visualize session execution as a waterfall/flamechart — where time is spent, what tools are called, where bottlenecks occur.
+
+| # | Task | Details |
+|---|---|---|
+| 11.1 | Research & data audit | Audit timing data available per provider (see `docs/research/session-tracing.md`) |
+| 11.2 | `TraceSpan` / `SessionTrace` data model | Common trace model with spans (request, tool, subagent, gap, error types) |
+| 11.3 | Trace builder: Copilot | Convert Copilot sessions to traces using native `totalElapsed` and `firstProgress` |
+| 11.4 | Trace builder: Claude | Derive request durations from message timestamps. Parse subagent sidechains. |
+| 11.5 | Trace waterfall webview | D3.js horizontal waterfall chart — requests as bars on a time axis, annotated with agent/model/tokens/tools |
+| 11.6 | Session health indicators | Rate limiting markers, long gaps, context growth overlay, timeout detection |
+| 11.7 | Tool call breakdown (Phase 2) | Nested tool-call spans within requests (Claude OTel data when available) |
+| 11.8 | Execution DAG for subagents (Phase 3) | Render subagent/sidechain execution as a DAG using `parentUuid` and `isSidechain` |
+
+**Branch:** `feature/session-tracing`
+**Definition of done:** Session trace waterfall renders for Copilot and Claude sessions. Bottlenecks and anomalies are visually highlighted.
+
+---
+
 ## Dependency Graph
 
 ```
@@ -178,12 +237,17 @@ M0 (Setup)
       └─→ M5 (Session Parser)
            └─→ M6 (Metrics Dashboard)
            └─→ M7 (Session Explorer)
+           └─→ M10 (Codex Support)
+           └─→ M11 (Session Tracing)
+      └─→ M9 (Claude Agent Discovery)
 
 M8 (Polish) depends on all above
 ```
 
 Milestones 3+4 (UI) and 5 (session parser) can run in parallel after M2 is done.
 Milestones 6+7 can run in parallel after M5 is done.
+Milestone 9 (Claude Agent Discovery) depends on M1 (parsers) and can run independently.
+Milestones 10+11 can run in parallel, both depend on the session parser infrastructure (M5).
 
 ---
 

--- a/docs/research/codex-sessions.md
+++ b/docs/research/codex-sessions.md
@@ -1,0 +1,182 @@
+# OpenAI Codex CLI — Session Data Research
+
+> Research into local session data stored by the OpenAI Codex CLI and VS Code extension, for integration into Agent Lens.
+
+---
+
+## 1. Where Codex Session Data Lives
+
+### Default location
+
+```
+~/.codex/sessions/<provider_id>/<YYYY-MM-DD>/<uuid>.jsonl
+```
+
+Configurable via the `CODEX_HOME` environment variable (defaults to `~/.codex/`).
+
+### Other local files
+
+| Path | Contents |
+|------|----------|
+| `~/.codex/config.toml` | Global configuration |
+| `~/.codex/history.jsonl` | Append-only session transcript log |
+| `~/.codex/AGENTS.md` | Global agent instructions |
+| `~/.codex/rules/` | Custom rules |
+| `~/.codex/log/` | Application logs |
+| `~/.codex/auth.json` | Credentials (if not using OS keychain) |
+
+### History file
+
+`~/.codex/history.jsonl` is a single append-only JSONL file with session transcripts. Controlled by `history.persistence` config (`save-all` or `none`). File size capped via `history.max_bytes`.
+
+### VS Code extension
+
+The Codex VS Code extension (`openai.chatgpt`) writes to the **same** `~/.codex/sessions/` directory as the CLI. Local tasks started from the extension produce the same `rollout-*.jsonl` files.
+
+---
+
+## 2. Rollout JSONL Format
+
+Each session is a single JSONL file. The format is **not officially documented** — the details below are reverse-engineered from community tools and GitHub issues.
+
+### Line 1: SessionMeta header
+
+```json
+{
+  "session_id": "uuid",
+  "timestamp": "2026-02-15T10:00:00Z",
+  "model": "gpt-5-codex",
+  "cli_version": "1.2.3"
+}
+```
+
+### Lines 2+: RolloutLine entries
+
+Each subsequent line is a `RolloutLine` wrapping either a `ResponseItem` or an `EventMsg`.
+
+### Event types (`EventMsg` with `payload.type`)
+
+| Event Type | Description |
+|---|---|
+| `token_count` | Cumulative token usage for the session |
+| `turn_started` | Marks the beginning of a new turn/generation |
+| `context_compacted` | Records when context compression occurred |
+
+### Token usage (from `token_count` events)
+
+| Field | Description |
+|---|---|
+| `total_token_usage` | Cumulative tokens consumed |
+| `last_token_usage` | Most recent usage snapshot |
+| `model_context_window` | Maximum context window size |
+| `cached_input_tokens` | Reused cached tokens |
+
+Per-turn deltas can be computed by subtracting previous `token_count` totals (input, cached input, output, reasoning, total).
+
+### Response items
+
+| Type | Description |
+|---|---|
+| `user_message` | User input (`{"type": "user_message", "message": "...", "images": []}`) |
+| `function_call` | Tool invocation (tool name, parameters) |
+| `function_call_output` | Tool execution result (success/failure, duration) |
+| Assistant messages | Role and content of assistant responses |
+
+### Session metadata (`turn_context`)
+
+| Field | Description |
+|---|---|
+| Model name | e.g., `gpt-5-codex` |
+| CLI version | Version of Codex CLI |
+| Sandbox/approval settings | Execution environment config |
+| Conversation ID | Links to conversation thread |
+
+---
+
+## 3. Timing Data
+
+### What's available
+
+| Data | Available | Notes |
+|---|---|---|
+| Session start time | Yes | `SessionMeta.timestamp` (RFC 3339) |
+| Per-event timestamps | **No** | Events in rollout JSONL have no individual timestamps |
+| Request duration | **No** | Cannot be computed from persisted data |
+| Tool call duration | **No** | `function_call`/`function_call_output` have no timing fields |
+
+### `--json` streaming output
+
+The `codex exec --json` flag emits structured events in real-time:
+
+| Event | Key Fields |
+|---|---|
+| `thread.started` | `thread_id` |
+| `turn.started` | (no timing fields) |
+| `turn.completed` | `usage.input_tokens`, `usage.output_tokens` |
+| `turn.failed` | Error information |
+| `item.started` | `item.id`, `item.type`, `item.command`, `item.status` |
+| `item.completed` | `item.id`, `item.type`, `item.text` |
+
+Item types: `command_execution`, `agent_message`, `reasoning`, `file_change`, `mcp_tool_call`, `web_search`, `plan_update`.
+
+**These events are streamed but not persisted.** Timing would require capturing them at ingestion time.
+
+### Community requests for timestamps
+
+- [Issue #8027](https://github.com/openai/codex/issues/8027) — `CODEX_TRACE_PATH` proposal to add `ts_ms` fields
+- [Issue #8620](https://github.com/openai/codex/issues/8620) — Request for `timestamp` on `thread.started`
+- [Issue #10407](https://github.com/openai/codex/issues/10407) — Request for stable session export format
+
+---
+
+## 4. Caveats
+
+- **Format is unstable**: OpenAI maintainers consider it internal and subject to change
+- **Historical gaps**: Sessions before September 2025 may lack `token_count` events and model metadata
+- **No per-event timestamps**: Makes trace/flamechart visualization impossible from persisted data alone
+- **VS Code extension is closed-source**: Only the CLI is Apache-2.0 ([Issue #5822](https://github.com/openai/codex/issues/5822))
+
+---
+
+## 5. Implementation Plan
+
+### Parser
+
+1. Discover rollout files in `~/.codex/sessions/` (or `CODEX_HOME`)
+2. Parse line 1 as `SessionMeta` for session-level metadata
+3. Iterate subsequent lines, classifying as `EventMsg` or `ResponseItem`
+4. Extract token usage from `token_count` events (compute deltas between consecutive events)
+5. Extract tool calls from `function_call` / `function_call_output` items
+6. Map to existing `Session` / `SessionRequest` model with `provider: "codex"`
+
+### Settings
+
+- `agentLens.codexDir` — custom path to Codex sessions directory
+- Respect `CODEX_HOME` environment variable as fallback
+
+### UI changes
+
+- Add "Codex" option to source filter toggle
+- Codex provider badge in Session Explorer (suggest green)
+
+---
+
+## 6. Community Tools
+
+| Tool | What it does |
+|------|-------------|
+| [ccusage](https://ccusage.com/guide/codex/) | Parses token counts from rollout JSONL, calculates costs |
+| [codex-hud](https://github.com/fwyc0573/codex-hud) | Real-time HUD for Codex CLI, parses `token_count`/`turn_started`/`context_compacted` events |
+| [codex_usage](https://lib.rs/crates/codex_usage) | Rust crate for Codex session analysis |
+
+---
+
+## References
+
+- [Codex CLI Features](https://developers.openai.com/codex/cli/features/)
+- [Codex Advanced Configuration](https://developers.openai.com/codex/config-advanced/)
+- [Codex Configuration Reference](https://developers.openai.com/codex/config-reference/)
+- [Codex IDE Extension](https://developers.openai.com/codex/ide/)
+- [GitHub Issue #2288 — JSON trajectory output](https://github.com/openai/codex/issues/2288)
+- [GitHub Issue #4963 — Log rotate history.jsonl](https://github.com/openai/codex/issues/4963)
+- [GitHub Discussion #2956 — Save chat history in VS Code](https://github.com/openai/codex/discussions/2956)

--- a/docs/research/session-tracing.md
+++ b/docs/research/session-tracing.md
@@ -1,0 +1,259 @@
+# Session Tracing & Execution Graphs — Research
+
+> Research into building trace visualizations from AI coding agent session data. The goal: show session execution as a waterfall/flamechart — where time is spent, what tools are called, where bottlenecks and throttling occur.
+
+---
+
+## 1. The Idea
+
+Current Agent Lens views show **what** happened (metrics, session timeline). Tracing shows **when** and **how long** — turning a session into an execution graph:
+
+```
+User message ──────────────────────────────────────────────── 45.2s total
+├─ API request (claude-opus-4-6) ─────────────── 12.3s
+│  └─ Tool: read_file ──── 0.8s
+│  └─ Tool: grep_search ── 1.2s
+├─ API request (claude-opus-4-6) ───────── 8.1s
+│  └─ Tool: write_file ─── 0.3s
+├─ API request (claude-opus-4-6) ──── 5.4s
+│  └─ Tool: run_terminal ──────────── 18.9s  ← bottleneck
+└─ API response (final) ── 0.3s
+```
+
+This answers questions like:
+- Where is time being spent — API calls or tool execution?
+- Is a specific tool consistently slow?
+- Are there long pauses (throttling? rate limits? user idle time)?
+- How does context size affect response time over a session?
+- Are subagent/sidechain calls adding latency?
+
+---
+
+## 2. Available Timing Data by Provider
+
+### GitHub Copilot
+
+**Best out-of-the-box timing.** The JSONL session format includes native timing fields per request.
+
+| Field | Unit | Description |
+|---|---|---|
+| `requests[].timestamp` | ms (epoch) | When the request was made |
+| `result.timings.totalElapsed` | ms | Total request duration (user → final response) |
+| `result.timings.firstProgress` | ms | Time to first streaming token |
+| `result.usage.promptTokens` | count | Input tokens |
+| `result.usage.completionTokens` | count | Output tokens |
+
+**What we can build:**
+- Request-level waterfall with exact durations
+- Time-to-first-token vs total duration (shows streaming lag)
+- Token count correlation with response time
+- Inter-request gaps (user think time vs system processing)
+
+**What we can't:**
+- Per-tool-call duration (tool calls have names/IDs but no individual timing)
+- API-level vs tool-level breakdown within a request
+
+### Claude Code
+
+**Timestamps on every message, but no explicit durations.** Every line in the JSONL carries an ISO 8601 `timestamp` with millisecond precision.
+
+| Field | Description |
+|---|---|
+| `timestamp` | ISO 8601 ms on every message (user, assistant, tool_result) |
+| `message.usage.*` | Token counts per response |
+| `message.model` | Model used |
+| `isSidechain` | Whether this is a subagent call |
+| `parentUuid` | Conversation threading |
+
+**What we can derive:**
+- Request duration: `assistant.timestamp - user.timestamp`
+- Per-turn duration in tool-use loops: successive `assistant` timestamps
+- Subagent execution time: sidechain message timestamp ranges
+- Session pacing: gaps between turns
+
+**What we can't (from JSONL alone):**
+- Per-tool execution duration (tool_use and tool_result are in the same assistant/user message pair)
+- API response time vs tool execution time
+- Rate limiting / retry information
+
+**OpenTelemetry (opt-in, not in JSONL):**
+
+When `CLAUDE_CODE_ENABLE_TELEMETRY=1` is set, Claude Code emits OTel events with rich timing:
+
+| Event | Key Fields |
+|---|---|
+| `claude_code.api_request` | `duration_ms`, `cost_usd` |
+| `claude_code.tool_result` | `duration_ms`, `tool_name`, `success` |
+| `claude_code.api_error` | `duration_ms`, `status_code`, `attempt` (retry count) |
+
+This is the **only source of per-tool `duration_ms`** across any provider. It also captures rate limiting (status 429) and retry counts. However, OTel events are exported to a collector, not written to session JSONL files.
+
+### OpenAI Codex CLI
+
+**Poorest timing data.** Rollout JSONL files lack per-event timestamps.
+
+| Data | Available |
+|---|---|
+| Session start time | Yes (`SessionMeta.timestamp`) |
+| Per-event timestamps | No |
+| Request duration | Cannot compute |
+| Tool call duration | Cannot compute |
+
+The `--json` streaming output has event structure (`turn.started`/`turn.completed`, `item.started`/`item.completed`) that maps well to traces, but carries no timing fields. Community has requested this ([Issue #8027](https://github.com/openai/codex/issues/8027)).
+
+---
+
+## 3. Comparative Summary
+
+| Capability | Copilot | Claude Code | Codex CLI |
+|---|---|---|---|
+| Request duration | Native (`totalElapsed`) | Derived (timestamp delta) | Not available |
+| Time to first token | Native (`firstProgress`) | Not available | Not available |
+| Per-tool duration | Not available | OTel only | Not available |
+| Timestamps per event | Per request (ms epoch) | Per message (ISO 8601 ms) | Session-level only |
+| Rate limit detection | No | OTel `api_error` (429) | No |
+| Retry tracking | No | OTel `attempt` field | No |
+| Subagent timing | N/A | Yes (`isSidechain` + timestamps) | No |
+
+---
+
+## 4. What We Can Build
+
+### Phase 1: Request Waterfall (Copilot + Claude)
+
+A horizontal waterfall chart showing each request as a bar, positioned on a time axis:
+
+```
+Time →  0s        5s        10s       15s       20s
+        ├─────────┼─────────┼─────────┼─────────┤
+Req 1   ████████░░                                  8.2s (░ = time to first token)
+Req 2              ███████████                     11.1s
+Req 3                          ████                 4.3s
+Req 4                              ████████████    12.0s
+```
+
+**Data needed:** request timestamp + totalElapsed (Copilot) or derived from message timestamps (Claude).
+
+Annotations per bar:
+- Agent name and model
+- Token count (prompt + completion)
+- Tool calls (count, names)
+- Agent/model switches highlighted
+
+### Phase 2: Tool Call Breakdown
+
+Where per-tool timing is available (Claude OTel), expand request bars into nested tool-call spans:
+
+```
+Req 2  ███████████████████████████████  11.1s
+       ├─ API response ──── 3.2s
+       ├─ read_file ──── 0.4s
+       ├─ API response ──── 2.8s
+       ├─ write_file ── 0.2s
+       ├─ run_terminal ──────── 4.5s  ← slowest
+```
+
+### Phase 3: Session Health Indicators
+
+Overlay indicators on the waterfall:
+
+| Indicator | Source | Visual |
+|---|---|---|
+| **Rate limiting** | Claude OTel 429 errors | Red marker on timeline |
+| **Retries** | Claude OTel `attempt > 1` | Retry count badge |
+| **Context growth** | Token counts over time | Line chart overlay |
+| **Long gaps** | Timestamp deltas between requests | Gray gap bars |
+| **Timeouts** | Missing responses, error events | Red X marker |
+| **Context compaction** | Codex `context_compacted`, Claude behavior | Orange marker |
+
+### Phase 4: Execution Graph (DAG)
+
+For sessions with subagents/sidechains (Claude Code), render an execution DAG:
+
+```
+Main thread ──────┬──── Subagent A ────┬──── continue ────
+                  │                    │
+                  └──── Subagent B ────┘
+```
+
+**Data needed:** `parentUuid`, `isSidechain`, `sessionId` threading from Claude Code JSONL.
+
+---
+
+## 5. Visualization Technology
+
+### Options
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **D3.js custom** | Full control, already used in Agent Lens | More code to write |
+| **Flame chart library** | Purpose-built for this | May not fit our exact model |
+| **SVG timeline** | Simple, lightweight | Limited interaction |
+| **Canvas-based** | Performance for large sessions | Harder accessibility |
+
+Recommendation: **D3.js custom** — we already have D3 in the project, and the visualization is close to a Gantt chart (horizontal bars on a time axis). D3's scale/axis utilities and transitions are a good fit.
+
+### Webview panel
+
+New command: `agentLens.openTrace` / "Agent Lens: Session Trace"
+
+Could be:
+- A new dedicated webview panel
+- An additional tab/mode within the existing Session Explorer
+
+---
+
+## 6. Data Model
+
+```typescript
+interface TraceSpan {
+  id: string;
+  parentId: string | null;     // for nesting (request → tool calls)
+  label: string;               // "API request", "read_file", etc.
+  startMs: number;             // relative to session start
+  durationMs: number;
+  type: 'request' | 'tool' | 'subagent' | 'gap' | 'error';
+  metadata: {
+    agent?: string;
+    model?: string;
+    promptTokens?: number;
+    completionTokens?: number;
+    toolName?: string;
+    isRetry?: boolean;
+    statusCode?: number;
+  };
+}
+
+interface SessionTrace {
+  sessionId: string;
+  provider: SessionProviderType;
+  startTime: Date;
+  totalDurationMs: number;
+  spans: TraceSpan[];
+}
+```
+
+The trace builder would convert provider-specific session data into this common `SessionTrace` model, similar to how we normalize into `Session`/`SessionRequest` today.
+
+---
+
+## 7. Implementation Phases
+
+| Phase | What | Depends on |
+|---|---|---|
+| **Phase 1** | Request waterfall (Copilot + Claude) | Existing session data |
+| **Phase 2** | Tool call breakdown (Claude OTel) | OTel data ingestion |
+| **Phase 3** | Session health indicators | Phase 1 + error/throttle detection |
+| **Phase 4** | Execution DAG for subagents | Phase 1 + Claude sidechain parsing |
+
+Phase 1 is achievable with data we already parse today. Phases 2-4 require additional data sources or deeper parsing.
+
+---
+
+## References
+
+- [Claude Code monitoring/OTel](https://code.claude.com/docs/en/monitoring-usage)
+- [Claude Code statusline](https://code.claude.com/docs/en/statusline)
+- [Codex CLI CODEX_TRACE_PATH proposal (Issue #8027)](https://github.com/openai/codex/issues/8027)
+- [ccusage](https://github.com/ryoppippi/ccusage) — token/cost analysis across providers
+- [Claude Code log analysis with DuckDB](https://liambx.com/blog/claude-code-log-analysis-with-duckdb)


### PR DESCRIPTION
## Summary
- Add research doc: `docs/research/codex-sessions.md` — OpenAI Codex CLI session format analysis
- Add research doc: `docs/research/session-tracing.md` — timing data audit across Copilot, Claude, and Codex
- Update ROADMAP.md with Milestones 9 (Claude agent discovery), 10 (Codex support), 11 (Session tracing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)