### PR TITLE
feat(codex): add OpenAI Codex CLI session support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- OpenAI Codex CLI session support: parses rollout JSONL files from `~/.codex/sessions/` into `Session`/`SessionRequest` model (closes #13)
+- `CodexSessionProvider` with file discovery, JSONL parsing, and file watching
+- Codex session locator: scans `agentLens.codexDir` setting, `CODEX_HOME` env, or default `~/.codex/sessions/`
+- "Codex" filter toggle in Session Explorer and Metrics Dashboard
+- Green provider badge for Codex sessions in Session Explorer
+- `agentLens.codexDir` configuration setting for devcontainer/remote environments
+- Codex section in Container Setup Guide with mount instructions
+- Updated research doc with verified Codex JSONL envelope format
+- 24 new tests for Codex parser and locator (163 total)
+
 ## [0.0.11] - 2026-02-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Understand what your AI coding agents are actually doing.**
 
-Agent Lens gives you visibility into your GitHub Copilot and Claude Code sessions — which agents ran, what models they used, how many tokens they consumed, and how your agent workflows connect.
+Agent Lens gives you visibility into your GitHub Copilot, Claude Code, and OpenAI Codex CLI sessions — which agents ran, what models they used, how many tokens they consumed, and how your agent workflows connect.
 
 ![Metrics Dashboard](https://raw.githubusercontent.com/23min/agent-lens/main/assets/screenshots/donuts.png)
 
@@ -24,7 +24,7 @@ Agent Lens answers these questions by parsing your local session data and presen
 
 ### Metrics Dashboard
 
-See token usage, model distribution, agent activity, tool calls, and skill usage at a glance. Filter by provider (Copilot, Claude, or both). Spot unused agents and skills that might need attention.
+See token usage, model distribution, agent activity, tool calls, and skill usage at a glance. Filter by provider (Copilot, Claude, Codex, or all). Spot unused agents and skills that might need attention.
 
 ### Agent & Skill Explorer
 
@@ -48,6 +48,7 @@ For Claude Code sessions: see cache read tokens, cache creation tokens, cache hi
 |------|----------------------|
 | **GitHub Copilot** | Chat session JSONL files from VS Code workspace storage. Detects custom agents (from `.github/agents/`) and skills (from `.github/skills/`). |
 | **Claude Code** | Session JSONL files from `~/.claude/projects/`. Detects custom agents and skills, parses sub-agent sessions and prompt caching metrics. |
+| **OpenAI Codex CLI** | Rollout JSONL files from `~/.codex/sessions/`. Parses turn-level token usage with cumulative delta computation, tool calls, and model tracking. |
 
 Session data stays local — Agent Lens only reads files already on your machine.
 
@@ -68,6 +69,7 @@ If your sessions live on a mounted host path, configure the directory manually:
 |---------|-------------|
 | `agentLens.sessionDir` | Path to Copilot chat session files (or a `workspaceStorage` root) |
 | `agentLens.claudeDir` | Path to Claude Code project files (e.g., a mounted `~/.claude/projects`) |
+| `agentLens.codexDir` | Path to Codex CLI sessions directory (e.g., a mounted `~/.codex/sessions`) |
 
 Use the **Agent Lens: Container Setup Guide** command for step-by-step instructions.
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Path to a directory containing Claude Code session files. Should point to the `projects/` directory (or a specific project directory). Useful in devcontainers where `~/.claude` lives on the host — mount it and point this setting to the mount path."
+        },
+        "agentLens.codexDir": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Path to OpenAI Codex CLI sessions directory. Useful in devcontainers — mount the host's `~/.codex/sessions` and point this setting to the mount path. Respects `CODEX_HOME` environment variable as fallback."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
 import type { SessionDiscoveryContext } from "./parsers/sessionProvider.js";
 import { CopilotSessionProvider } from "./parsers/copilotProvider.js";
 import { ClaudeSessionProvider } from "./parsers/claudeProvider.js";
+import { CodexSessionProvider } from "./parsers/codexProvider.js";
 import { buildGraph } from "./analyzers/graphBuilder.js";
 import { AgentLensTreeProvider } from "./views/treeProvider.js";
 import { initLogger, getLogger } from "./logger.js";
@@ -79,6 +80,7 @@ export function activate(context: vscode.ExtensionContext): void {
   // Register session providers
   registerSessionProvider(new CopilotSessionProvider());
   registerSessionProvider(new ClaudeSessionProvider());
+  registerSessionProvider(new CodexSessionProvider());
 
   const sessionCtx: SessionDiscoveryContext = {
     extensionContext: context,

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -31,7 +31,7 @@ export interface SkillRef {
   file: string;
 }
 
-export type SessionProviderType = "copilot" | "claude";
+export type SessionProviderType = "copilot" | "claude" | "codex";
 
 export interface Session {
   sessionId: string;

--- a/src/parsers/codexLocator.test.ts
+++ b/src/parsers/codexLocator.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getCodexSessionsDir } from "./codexLocator.js";
+import * as os from "node:os";
+import * as path from "node:path";
+
+describe("getCodexSessionsDir", () => {
+  const originalEnv = process.env.CODEX_HOME;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalEnv;
+    }
+  });
+
+  it("returns configDir when provided", () => {
+    process.env.CODEX_HOME = "/some/codex/home";
+    const result = getCodexSessionsDir("/custom/path");
+    expect(result).toBe("/custom/path");
+  });
+
+  it("uses CODEX_HOME env var when no configDir", () => {
+    process.env.CODEX_HOME = "/my/codex";
+    const result = getCodexSessionsDir();
+    expect(result).toBe(path.join("/my/codex", "sessions"));
+  });
+
+  it("falls back to ~/.codex/sessions when no configDir or env var", () => {
+    delete process.env.CODEX_HOME;
+    const result = getCodexSessionsDir();
+    expect(result).toBe(path.join(os.homedir(), ".codex", "sessions"));
+  });
+
+  it("prefers configDir over CODEX_HOME", () => {
+    process.env.CODEX_HOME = "/env/codex";
+    const result = getCodexSessionsDir("/config/path");
+    expect(result).toBe("/config/path");
+  });
+});

--- a/src/parsers/codexLocator.ts
+++ b/src/parsers/codexLocator.ts
@@ -1,0 +1,54 @@
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs/promises";
+
+export interface CodexSessionEntry {
+  fullPath: string;
+}
+
+/**
+ * Determine the Codex sessions root directory.
+ * Priority: configDir parameter > CODEX_HOME env > ~/.codex/sessions
+ */
+export function getCodexSessionsDir(configDir?: string): string {
+  if (configDir) return configDir;
+  const codexHome = process.env.CODEX_HOME;
+  if (codexHome) return path.join(codexHome, "sessions");
+  return path.join(os.homedir(), ".codex", "sessions");
+}
+
+/**
+ * Recursively discover all .jsonl files under the given sessions directory.
+ * Traverses the <provider_id>/<date>/ directory structure.
+ */
+export async function discoverCodexSessions(
+  sessionsDir: string,
+): Promise<CodexSessionEntry[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sessionsDir);
+  } catch {
+    return [];
+  }
+
+  const results: CodexSessionEntry[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(sessionsDir, entry);
+    let stat;
+    try {
+      stat = await fs.stat(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      // Recurse into subdirectories (provider_id, date folders)
+      const nested = await discoverCodexSessions(fullPath);
+      results.push(...nested);
+    } else if (entry.endsWith(".jsonl")) {
+      results.push({ fullPath });
+    }
+  }
+
+  return results;
+}

--- a/src/parsers/codexProvider.ts
+++ b/src/parsers/codexProvider.ts
@@ -1,0 +1,98 @@
+import * as vscode from "vscode";
+import * as fs from "node:fs/promises";
+import { getCodexSessionsDir, discoverCodexSessions } from "./codexLocator.js";
+import { parseCodexSessionJsonl } from "./codexSessionParser.js";
+import type { Session } from "../models/session.js";
+import type {
+  SessionProvider,
+  SessionDiscoveryContext,
+  WatchTarget,
+} from "./sessionProvider.js";
+import { getLogger } from "../logger.js";
+
+export class CodexSessionProvider implements SessionProvider {
+  readonly name = "Codex";
+
+  async discoverSessions(ctx: SessionDiscoveryContext): Promise<Session[]> {
+    const log = getLogger();
+
+    const configDir = vscode.workspace
+      .getConfiguration("agentLens")
+      .get<string>("codexDir");
+
+    // Scan both configDir and default location, merge results
+    const seen = new Set<string>();
+    const allEntries = [];
+
+    // 1. User-configured codexDir
+    if (configDir) {
+      log.info(`Codex: scanning configured codexDir = "${configDir}"`);
+      const configEntries = await discoverCodexSessions(configDir);
+      log.info(`  Found ${configEntries.length} session(s) via configured dir`);
+      for (const entry of configEntries) {
+        seen.add(entry.fullPath);
+        allEntries.push(entry);
+      }
+    }
+
+    // 2. Default location (CODEX_HOME or ~/.codex/sessions)
+    const defaultDir = getCodexSessionsDir();
+    const defaultEntries = await discoverCodexSessions(defaultDir);
+    log.info(`  Found ${defaultEntries.length} session(s) via default path (${defaultDir})`);
+    for (const entry of defaultEntries) {
+      if (!seen.has(entry.fullPath)) {
+        allEntries.push(entry);
+      }
+    }
+
+    if (allEntries.length === 0) return [];
+
+    log.info(`Codex: parsing ${allEntries.length} session(s)`);
+    const sessions: Session[] = [];
+
+    for (const entry of allEntries) {
+      try {
+        const content = await fs.readFile(entry.fullPath, "utf-8");
+        const session = parseCodexSessionJsonl(content);
+        if (session.requests.length > 0) {
+          sessions.push(session);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(`  Skipping Codex session "${entry.fullPath}": ${msg}`);
+      }
+    }
+
+    log.info(`Codex: parsed ${sessions.length} session(s)`);
+    return sessions;
+  }
+
+  getWatchTargets(ctx: SessionDiscoveryContext): WatchTarget[] {
+    const targets: WatchTarget[] = [];
+
+    const configDir = vscode.workspace
+      .getConfiguration("agentLens")
+      .get<string>("codexDir");
+
+    if (configDir) {
+      targets.push({
+        pattern: new vscode.RelativePattern(
+          vscode.Uri.file(configDir),
+          "**/*.jsonl",
+        ),
+        events: ["create", "change"],
+      });
+    }
+
+    const defaultDir = getCodexSessionsDir();
+    targets.push({
+      pattern: new vscode.RelativePattern(
+        vscode.Uri.file(defaultDir),
+        "**/*.jsonl",
+      ),
+      events: ["create", "change"],
+    });
+
+    return targets;
+  }
+}

--- a/src/parsers/codexSessionParser.test.ts
+++ b/src/parsers/codexSessionParser.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from "vitest";
+import { parseCodexSessionJsonl } from "./codexSessionParser.js";
+
+/* ------------------------------------------------------------------ */
+/*  Test helpers — build JSONL envelope lines                         */
+/* ------------------------------------------------------------------ */
+
+function sessionMeta(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    timestamp: "2026-02-15T13:00:00.000Z",
+    type: "session_meta",
+    payload: {
+      id: "test-session-id",
+      timestamp: "2026-02-15T13:00:00.000Z",
+      cli_version: "0.100.0",
+      model_provider: "openai",
+      source: "cli",
+      ...overrides,
+    },
+  });
+}
+
+function eventMsg(type: string, extra: Record<string, unknown> = {}, ts?: string): string {
+  return JSON.stringify({
+    timestamp: ts ?? "2026-02-15T13:01:00.000Z",
+    type: "event_msg",
+    payload: { type, ...extra },
+  });
+}
+
+function responseItem(
+  type: string,
+  extra: Record<string, unknown> = {},
+  ts?: string,
+): string {
+  return JSON.stringify({
+    timestamp: ts ?? "2026-02-15T13:01:00.000Z",
+    type: "response_item",
+    payload: { type, ...extra },
+  });
+}
+
+function turnContext(model: string): string {
+  return JSON.stringify({
+    timestamp: "2026-02-15T13:01:00.000Z",
+    type: "turn_context",
+    payload: { model },
+  });
+}
+
+function userMessage(text: string): string {
+  return responseItem("message", {
+    role: "user",
+    content: [{ type: "input_text", text }],
+  });
+}
+
+function assistantMessage(text: string, phase?: string): string {
+  return responseItem("message", {
+    role: "assistant",
+    content: [{ type: "output_text", text }],
+    ...(phase ? { phase } : {}),
+  });
+}
+
+function functionCall(name: string, callId: string): string {
+  return responseItem("function_call", {
+    name,
+    call_id: callId,
+    arguments: "{}",
+  });
+}
+
+function functionCallOutput(callId: string, output: string): string {
+  return responseItem("function_call_output", {
+    call_id: callId,
+    output,
+  });
+}
+
+function tokenCount(
+  total: { input_tokens: number; cached_input_tokens: number; output_tokens: number },
+): string {
+  return eventMsg("token_count", {
+    info: {
+      total_token_usage: { ...total, total_tokens: total.input_tokens + total.output_tokens },
+      last_token_usage: total,
+    },
+  });
+}
+
+function tokenCountNull(): string {
+  return eventMsg("token_count", { info: null });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                             */
+/* ------------------------------------------------------------------ */
+
+describe("parseCodexSessionJsonl", () => {
+  it("parses session metadata from envelope", () => {
+    const content = [
+      sessionMeta({ id: "abc-123", timestamp: "2026-01-20T10:00:00.000Z" }),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.sessionId).toBe("abc-123");
+    expect(session.creationDate).toBe(new Date("2026-01-20T10:00:00.000Z").getTime());
+    expect(session.provider).toBe("codex");
+    expect(session.source).toBe("codex");
+    expect(session.requests).toHaveLength(0);
+  });
+
+  it("returns empty session for empty input", () => {
+    const session = parseCodexSessionJsonl("");
+    expect(session.requests).toHaveLength(0);
+  });
+
+  it("returns empty session for malformed first line", () => {
+    const session = parseCodexSessionJsonl("not json");
+    expect(session.requests).toHaveLength(0);
+  });
+
+  it("returns empty session when first line is not session_meta", () => {
+    const content = eventMsg("task_started");
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(0);
+  });
+
+  it("parses a single turn with task_started and task_complete", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("user_message", { message: "Hello Codex" }),
+      eventMsg("task_started", { turn_id: "turn-1" }),
+      userMessage("Hello Codex"),
+      assistantMessage("Hi there", "final_answer"),
+      tokenCount({ input_tokens: 1000, cached_input_tokens: 500, output_tokens: 200 }),
+      eventMsg("task_complete", { turn_id: "turn-1" }),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(1);
+
+    const req = session.requests[0];
+    expect(req.requestId).toBe("codex-turn-0");
+    expect(req.messageText).toBe("Hello Codex");
+    expect(req.agentId).toBe("codex-cli");
+    expect(req.usage.promptTokens).toBe(1000);
+    expect(req.usage.completionTokens).toBe(200);
+    expect(req.usage.cacheReadTokens).toBe(500);
+  });
+
+  it("parses multi-turn session with cumulative token deltas", () => {
+    const content = [
+      sessionMeta(),
+      // Turn 1
+      eventMsg("task_started", { turn_id: "t1" }),
+      userMessage("First question"),
+      tokenCount({ input_tokens: 1000, cached_input_tokens: 500, output_tokens: 200 }),
+      eventMsg("task_complete", { turn_id: "t1" }),
+      // Turn 2
+      eventMsg("task_started", { turn_id: "t2" }),
+      userMessage("Second question"),
+      tokenCount({ input_tokens: 2500, cached_input_tokens: 1800, output_tokens: 500 }),
+      eventMsg("task_complete", { turn_id: "t2" }),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(2);
+
+    // Turn 1: absolute values (no previous)
+    expect(session.requests[0].usage.promptTokens).toBe(1000);
+    expect(session.requests[0].usage.completionTokens).toBe(200);
+    expect(session.requests[0].usage.cacheReadTokens).toBe(500);
+
+    // Turn 2: delta from turn 1
+    expect(session.requests[1].usage.promptTokens).toBe(1500);
+    expect(session.requests[1].usage.completionTokens).toBe(300);
+    expect(session.requests[1].usage.cacheReadTokens).toBe(1300);
+  });
+
+  it("extracts tool calls from function_call response_items", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      userMessage("Run a command"),
+      functionCall("exec_command", "call_abc"),
+      functionCallOutput("call_abc", "done"),
+      functionCall("apply_patch", "call_def"),
+      functionCallOutput("call_def", "patched"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(1);
+    expect(session.requests[0].toolCalls).toEqual([
+      { id: "call_abc", name: "exec_command" },
+      { id: "call_def", name: "apply_patch" },
+    ]);
+  });
+
+  it("handles token_count with info: null gracefully", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      userMessage("Test"),
+      tokenCountNull(),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(1);
+    expect(session.requests[0].usage.promptTokens).toBe(0);
+    expect(session.requests[0].usage.completionTokens).toBe(0);
+  });
+
+  it("skips malformed lines without crashing", () => {
+    const content = [
+      sessionMeta(),
+      "not valid json {{{",
+      eventMsg("task_started"),
+      userMessage("Still works"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(1);
+    expect(session.requests[0].messageText).toBe("Still works");
+  });
+
+  it("uses model from turn_context", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      turnContext("gpt-5.3-codex"),
+      userMessage("Hi"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests[0].modelId).toBe("gpt-5.3-codex");
+  });
+
+  it("falls back to model_provider when no turn_context", () => {
+    const content = [
+      sessionMeta({ model_provider: "openai" }),
+      eventMsg("task_started"),
+      userMessage("Hi"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests[0].modelId).toBe("openai");
+  });
+
+  it("handles session without explicit task_started (older format)", () => {
+    const content = [
+      sessionMeta(),
+      userMessage("Older format question"),
+      assistantMessage("Answer"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(1);
+    expect(session.requests[0].messageText).toBe("Older format question");
+  });
+
+  it("handles turn_aborted event", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      userMessage("Do something"),
+      functionCall("exec_command", "call_1"),
+      eventMsg("turn_aborted", { reason: "interrupted" }),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(1);
+    expect(session.requests[0].toolCalls).toHaveLength(1);
+  });
+
+  it("uses event_msg user_message when inside a turn", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      eventMsg("user_message", { message: "From event" }),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests).toHaveLength(1);
+    expect(session.requests[0].messageText).toBe("From event");
+  });
+
+  it("sequential request IDs are 0-indexed", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      userMessage("Q1"),
+      eventMsg("task_complete"),
+      eventMsg("task_started"),
+      userMessage("Q2"),
+      eventMsg("task_complete"),
+      eventMsg("task_started"),
+      userMessage("Q3"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests.map((r) => r.requestId)).toEqual([
+      "codex-turn-0",
+      "codex-turn-1",
+      "codex-turn-2",
+    ]);
+  });
+
+  it("title is always null", () => {
+    const content = [sessionMeta()].join("\n");
+    const session = parseCodexSessionJsonl(content);
+    expect(session.title).toBeNull();
+  });
+
+  it("timings are null", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      userMessage("Test"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests[0].timings.firstProgress).toBeNull();
+    expect(session.requests[0].timings.totalElapsed).toBeNull();
+  });
+
+  it("skills are always empty", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      userMessage("Test"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests[0].availableSkills).toEqual([]);
+    expect(session.requests[0].loadedSkills).toEqual([]);
+  });
+
+  it("handles multiple token_count events per turn (takes last)", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      userMessage("Test"),
+      tokenCount({ input_tokens: 100, cached_input_tokens: 50, output_tokens: 20 }),
+      tokenCount({ input_tokens: 500, cached_input_tokens: 300, output_tokens: 100 }),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    // Should use the last token_count (highest cumulative values)
+    expect(session.requests[0].usage.promptTokens).toBe(500);
+    expect(session.requests[0].usage.completionTokens).toBe(100);
+    expect(session.requests[0].usage.cacheReadTokens).toBe(300);
+  });
+
+  it("ignores developer and assistant messages for user text", () => {
+    const content = [
+      sessionMeta(),
+      eventMsg("task_started"),
+      responseItem("message", {
+        role: "developer",
+        content: [{ type: "input_text", text: "system prompt" }],
+      }),
+      userMessage("actual user question"),
+      assistantMessage("response"),
+      eventMsg("task_complete"),
+    ].join("\n");
+
+    const session = parseCodexSessionJsonl(content);
+    expect(session.requests[0].messageText).toBe("actual user question");
+  });
+});

--- a/src/parsers/codexSessionParser.ts
+++ b/src/parsers/codexSessionParser.ts
@@ -1,0 +1,272 @@
+import type {
+  Session,
+  SessionRequest,
+  ToolCallInfo,
+} from "../models/session.js";
+
+/* ------------------------------------------------------------------ */
+/*  Codex JSONL envelope types                                        */
+/* ------------------------------------------------------------------ */
+
+/** Every line in a Codex rollout file is a typed envelope. */
+interface CodexLine {
+  timestamp: string;
+  type: "session_meta" | "response_item" | "event_msg" | "turn_context";
+  payload: Record<string, unknown>;
+}
+
+/* -- session_meta -------------------------------------------------- */
+interface SessionMetaPayload {
+  id?: string;
+  timestamp?: string;
+  cli_version?: string;
+  model_provider?: string;
+  source?: string;
+}
+
+/* -- response_item ------------------------------------------------- */
+interface ResponseItemPayload {
+  type: string;           // message | function_call | function_call_output | reasoning | ...
+  role?: string;          // user | assistant | developer | cwd
+  content?: ContentPart[];
+  phase?: string;         // commentary | final_answer
+  name?: string;          // tool name (function_call)
+  call_id?: string;       // tool call id
+  end_turn?: boolean;
+}
+
+interface ContentPart {
+  type: string;           // input_text | output_text | summary_text | input_image
+  text?: string;
+}
+
+/* -- event_msg ----------------------------------------------------- */
+interface EventMsgPayload {
+  type: string;           // task_started | task_complete | token_count | user_message | ...
+  turn_id?: string;
+  message?: string;       // user_message.message / agent_message.message
+  info?: TokenInfo | null;
+}
+
+interface TokenInfo {
+  total_token_usage?: TokenUsage;
+  last_token_usage?: TokenUsage;
+}
+
+interface TokenUsage {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+  reasoning_output_tokens?: number;
+  total_tokens?: number;
+}
+
+/* -- turn_context -------------------------------------------------- */
+interface TurnContextPayload {
+  turn_id?: string;
+  model?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Parser                                                            */
+/* ------------------------------------------------------------------ */
+
+interface TurnState {
+  userMessage: string;
+  toolCalls: ToolCallInfo[];
+  model: string;
+  timestamp: number;
+  lastTokenUsage: TokenUsage | null;
+}
+
+function emptyTurnState(model: string, timestamp: number): TurnState {
+  return {
+    userMessage: "",
+    toolCalls: [],
+    model,
+    timestamp,
+    lastTokenUsage: null,
+  };
+}
+
+export function parseCodexSessionJsonl(content: string): Session {
+  const lines = content.split("\n").filter((l) => l.trim());
+  if (lines.length === 0) return emptySession();
+
+  // Parse first line — must be session_meta
+  let firstLine: CodexLine;
+  try {
+    firstLine = JSON.parse(lines[0]);
+  } catch {
+    return emptySession();
+  }
+
+  if (firstLine.type !== "session_meta") return emptySession();
+
+  const meta = firstLine.payload as unknown as SessionMetaPayload;
+  const sessionId = meta.id ?? `codex-${Date.now()}`;
+  const creationDate = meta.timestamp
+    ? new Date(meta.timestamp).getTime()
+    : 0;
+  const defaultModel = meta.model_provider ?? "codex";
+
+  const requests: SessionRequest[] = [];
+  let currentTurn: TurnState | null = null;
+  let sessionModel = defaultModel;
+  let previousTotalTokens: TokenUsage = {};
+
+  function finalizeTurn(): void {
+    if (!currentTurn) return;
+
+    const usage = computeUsage(currentTurn.lastTokenUsage, previousTotalTokens);
+    if (currentTurn.lastTokenUsage) {
+      previousTotalTokens = currentTurn.lastTokenUsage;
+    }
+
+    requests.push({
+      requestId: `codex-turn-${requests.length}`,
+      timestamp: currentTurn.timestamp || creationDate,
+      agentId: "codex-cli",
+      customAgentName: null,
+      modelId: currentTurn.model,
+      messageText: currentTurn.userMessage,
+      timings: { firstProgress: null, totalElapsed: null },
+      usage,
+      toolCalls: currentTurn.toolCalls,
+      availableSkills: [],
+      loadedSkills: [],
+    });
+
+    currentTurn = null;
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    let line: CodexLine;
+    try {
+      line = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+
+    const lineTs = line.timestamp
+      ? new Date(line.timestamp).getTime()
+      : creationDate;
+
+    if (line.type === "event_msg") {
+      const evt = line.payload as unknown as EventMsgPayload;
+
+      if (evt.type === "task_started") {
+        finalizeTurn();
+        currentTurn = emptyTurnState(sessionModel, lineTs);
+      } else if (evt.type === "task_complete" || evt.type === "turn_aborted") {
+        finalizeTurn();
+      } else if (evt.type === "user_message") {
+        // Captures user message text for current or upcoming turn
+        const msg = evt.message ?? "";
+        if (currentTurn) {
+          currentTurn.userMessage = msg;
+        }
+      } else if (evt.type === "token_count") {
+        if (evt.info?.total_token_usage && currentTurn) {
+          currentTurn.lastTokenUsage = evt.info.total_token_usage;
+        }
+      }
+    } else if (line.type === "response_item") {
+      const item = line.payload as unknown as ResponseItemPayload;
+
+      // Ensure we have a turn (older sessions may lack task_started)
+      if (!currentTurn) {
+        currentTurn = emptyTurnState(sessionModel, lineTs);
+      }
+
+      if (item.type === "message" && item.role === "user") {
+        // Extract user message text from content array
+        const text = extractTextFromContent(item.content);
+        if (text) {
+          currentTurn.userMessage = text;
+        }
+      } else if (item.type === "function_call") {
+        currentTurn.toolCalls.push({
+          id: item.call_id ?? "",
+          name: item.name ?? "unknown",
+        });
+      }
+    } else if (line.type === "turn_context") {
+      const ctx = line.payload as unknown as TurnContextPayload;
+      if (ctx.model) {
+        sessionModel = ctx.model;
+        if (currentTurn) {
+          currentTurn.model = ctx.model;
+        }
+      }
+    }
+  }
+
+  // Finalize any open turn
+  finalizeTurn();
+
+  return {
+    sessionId,
+    title: null,
+    creationDate,
+    requests,
+    source: "codex",
+    provider: "codex",
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function extractTextFromContent(
+  content: ContentPart[] | undefined,
+): string {
+  if (!content) return "";
+  const parts: string[] = [];
+  for (const c of content) {
+    if ((c.type === "input_text" || c.type === "output_text") && c.text) {
+      parts.push(c.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function computeUsage(
+  turnTotal: TokenUsage | null,
+  previousTotal: TokenUsage,
+): {
+  promptTokens: number;
+  completionTokens: number;
+  cacheReadTokens: number;
+} {
+  if (!turnTotal) {
+    return { promptTokens: 0, completionTokens: 0, cacheReadTokens: 0 };
+  }
+  return {
+    promptTokens: Math.max(
+      0,
+      (turnTotal.input_tokens ?? 0) - (previousTotal.input_tokens ?? 0),
+    ),
+    completionTokens: Math.max(
+      0,
+      (turnTotal.output_tokens ?? 0) - (previousTotal.output_tokens ?? 0),
+    ),
+    cacheReadTokens: Math.max(
+      0,
+      (turnTotal.cached_input_tokens ?? 0) -
+        (previousTotal.cached_input_tokens ?? 0),
+    ),
+  };
+}
+
+function emptySession(): Session {
+  return {
+    sessionId: `codex-empty-${Date.now()}`,
+    title: null,
+    creationDate: 0,
+    requests: [],
+    source: "codex",
+    provider: "codex",
+  };
+}

--- a/webview/metrics.ts
+++ b/webview/metrics.ts
@@ -10,7 +10,7 @@ declare function acquireVsCodeApi(): {
 
 const vscode = acquireVsCodeApi();
 
-type SourceFilter = "all" | "copilot" | "claude";
+type SourceFilter = "all" | "copilot" | "claude" | "codex";
 
 interface CountEntry {
   name: string;
@@ -628,6 +628,7 @@ class MetricsDashboard extends LitElement {
       { value: "all", label: "All" },
       { value: "copilot", label: "Copilot" },
       { value: "claude", label: "Claude" },
+      { value: "codex", label: "Codex" },
     ];
 
     return html`

--- a/webview/session.ts
+++ b/webview/session.ts
@@ -9,7 +9,7 @@ declare function acquireVsCodeApi(): {
 
 const vscode = acquireVsCodeApi();
 
-type SourceFilter = "all" | "copilot" | "claude";
+type SourceFilter = "all" | "copilot" | "claude" | "codex";
 
 interface ToolCallInfo {
   id: string;
@@ -47,7 +47,7 @@ interface Session {
   creationDate: number;
   requests: SessionRequest[];
   source: string;
-  provider: "copilot" | "claude";
+  provider: "copilot" | "claude" | "codex";
 }
 
 @customElement("session-explorer")
@@ -309,6 +309,10 @@ class SessionExplorer extends LitElement {
       background: rgba(176, 144, 144, 0.15);
       color: #b09090;
     }
+    .provider-badge.codex {
+      background: rgba(138, 171, 127, 0.15);
+      color: #8aab7f;
+    }
   `;
 
   @state() private sessions: Session[] = [];
@@ -382,6 +386,7 @@ class SessionExplorer extends LitElement {
       { value: "all", label: "All" },
       { value: "copilot", label: "Copilot" },
       { value: "claude", label: "Claude" },
+      { value: "codex", label: "Codex" },
     ];
 
     return html`
@@ -409,7 +414,7 @@ class SessionExplorer extends LitElement {
               }}"
             >
               <span class="provider-badge ${session.provider}">
-                ${session.provider === "copilot" ? "Copilot" : "Claude"}
+                ${session.provider === "copilot" ? "Copilot" : session.provider === "claude" ? "Claude" : "Codex"}
               </span>
               <span class="session-title">
                 ${session.title ?? session.sessionId}

--- a/webview/setup.ts
+++ b/webview/setup.ts
@@ -134,6 +134,25 @@ class ContainerSetup extends LitElement {
         <li>Rebuild the container.</li>
       </ol>
 
+      <h2>OpenAI Codex CLI Sessions</h2>
+      <ol>
+        <li>
+          Add a bind mount to your <code>devcontainer.json</code>:
+          <pre>"mounts": [
+  "source=\${localEnv:HOME}/.codex/sessions,target=/mnt/codex-sessions,type=bind,readonly"
+]</pre>
+        </li>
+        <li>
+          Set the <code>agentLens.codexDir</code> setting to the mount path:
+          <pre>"agentLens.codexDir": "/mnt/codex-sessions"</pre>
+        </li>
+        <li>Rebuild the container.</li>
+      </ol>
+      <p class="note">
+        If you use a custom <code>CODEX_HOME</code>, mount
+        <code>$CODEX_HOME/sessions</code> instead.
+      </p>
+
       <h2>Already have a mount?</h2>
       <p>
         If your host data is already mounted somewhere in the container, you
@@ -148,6 +167,10 @@ class ContainerSetup extends LitElement {
         <li>
           <code>agentLens.claudeDir</code> — point to the
           <code>projects/</code> directory inside <code>.claude</code>
+        </li>
+        <li>
+          <code>agentLens.codexDir</code> — point to the
+          <code>sessions/</code> directory inside <code>.codex</code>
         </li>
       </ul>
 


### PR DESCRIPTION
## Summary
- Adds `CodexSessionProvider` with JSONL parser, file locator, and provider registration
- Parser handles real Codex typed envelope format (`session_meta`, `response_item`, `event_msg`, `turn_context`) with cumulative token delta computation, tool call extraction, and turn lifecycle tracking
- Codex filter toggles and green provider badge in Session Explorer and Metrics Dashboard
- `agentLens.codexDir` setting + Container Setup Guide section for devcontainer environments
- Updated research doc (`docs/research/codex-sessions.md`) with verified JSONL format

## New files
- `src/parsers/codexSessionParser.ts` — JSONL parser (20 tests)
- `src/parsers/codexLocator.ts` — file discovery with config/env/default fallback (4 tests)
- `src/parsers/codexProvider.ts` — `SessionProvider` implementation

## Test plan
- [x] 163 tests pass (`npm test`)
- [x] Build clean (`npm run build`)
- [ ] Manual: place a Codex rollout JSONL in `~/.codex/sessions/`, open Session Explorer, verify sessions appear with green Codex badge
- [ ] Manual: verify Codex filter toggle works in both Session Explorer and Metrics Dashboard

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)