### PR TITLE
feat(discovery): add Claude Code skill discovery

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,11 @@
+---
+name: Implementer
+description: Write and modify code. Use this for implementing features, fixing bugs, and refactoring.
+---
+
+You are an implementation assistant. When writing code:
+
+1. Follow existing patterns in the codebase
+2. Write tests alongside implementation (TDD when possible)
+3. Keep changes minimal and focused
+4. Explain non-obvious decisions in comments

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,0 +1,13 @@
+---
+name: Planner
+description: Design and plan implementation tasks. Use this when discussing architecture, making technical decisions, or breaking down features into steps.
+---
+
+You are a planning assistant. When asked to plan or design something:
+
+1. Understand the requirements and constraints
+2. Identify key technical decisions
+3. Break the work into ordered steps
+4. Flag risks or open questions
+
+Keep plans concise and actionable.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,11 @@
+---
+name: Reviewer
+description: Review code for correctness, style, and potential issues. Use this after implementation to catch problems.
+---
+
+You are a code reviewer. When reviewing:
+
+1. Check for correctness and edge cases
+2. Look for security issues
+3. Verify test coverage
+4. Suggest simplifications where possible

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: testing
+description: Guide for writing tests. Use this when creating unit tests, integration tests, or setting up test infrastructure.
+---
+
+# Testing Patterns
+
+## TDD workflow
+1. Write a failing test (red)
+2. Write minimal code to pass (green)
+3. Refactor while keeping tests green
+
+## Vitest conventions
+- Test files: `*.test.ts` next to source files
+- Use `describe` / `it` blocks
+- Prefer `expect` assertions
+- Mock external dependencies, not internal logic

--- a/.claude/skills/vscode-extensions/SKILL.md
+++ b/.claude/skills/vscode-extensions/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: vscode-extensions
+description: Guide for developing VS Code extensions. Use this when creating or modifying extension code, webviews, tree views, or commands.
+---
+
+# VS Code Extension Development
+
+## Extension structure
+- `extension.ts` — activation point, register commands and views
+- `package.json` — contributes commands, views, configuration
+- Webviews use message passing (`postMessage` / `onDidReceiveMessage`)
+
+## Webview security
+- Use `webview.asWebviewUri()` for local resources
+- Set a restrictive Content-Security-Policy
+- Bundle dependencies locally, never load from CDN
+
+## Testing
+- Use `@vscode/test-electron` for integration tests
+- Unit test pure logic separately with vitest

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "activationEvents": [
     "workspaceContains:**/.github/agents/*.agent.md",
     "workspaceContains:**/.github/skills/*/SKILL.md",
-    "workspaceContains:**/.claude/agents/*.md"
+    "workspaceContains:**/.claude/agents/*.md",
+    "workspaceContains:**/.claude/skills/*/SKILL.md"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,6 +155,9 @@ export function activate(context: vscode.ExtensionContext): void {
   const skillFlatWatcher = vscode.workspace.createFileSystemWatcher(
     "**/.github/skills/*.skill.md",
   );
+  const claudeSkillWatcher = vscode.workspace.createFileSystemWatcher(
+    "**/.claude/skills/*/SKILL.md",
+  );
 
   agentWatcher.onDidCreate(scheduleRefresh);
   agentWatcher.onDidChange(scheduleRefresh);
@@ -168,6 +171,9 @@ export function activate(context: vscode.ExtensionContext): void {
   skillFlatWatcher.onDidCreate(scheduleRefresh);
   skillFlatWatcher.onDidChange(scheduleRefresh);
   skillFlatWatcher.onDidDelete(scheduleRefresh);
+  claudeSkillWatcher.onDidCreate(scheduleRefresh);
+  claudeSkillWatcher.onDidChange(scheduleRefresh);
+  claudeSkillWatcher.onDidDelete(scheduleRefresh);
 
   context.subscriptions.push(
     outputChannel,
@@ -181,6 +187,7 @@ export function activate(context: vscode.ExtensionContext): void {
     claudeAgentWatcher,
     skillWatcher,
     skillFlatWatcher,
+    claudeSkillWatcher,
   );
 
   // Watch session files from all providers

--- a/src/parsers/discovery.ts
+++ b/src/parsers/discovery.ts
@@ -13,6 +13,7 @@ const CLAUDE_AGENT_GLOB = "**/.claude/agents/*.md";
 const SKILL_GLOBS = [
   "**/.github/skills/*/SKILL.md",
   "**/.github/skills/*.skill.md",
+  "**/.claude/skills/*/SKILL.md",
 ];
 
 async function discoverCopilotAgents(): Promise<Agent[]> {

--- a/src/parsers/skillParser.test.ts
+++ b/src/parsers/skillParser.test.ts
@@ -91,4 +91,25 @@ Content.`;
     const skill = parseSkill(content, ".github/skills/branching.skill.md");
     expect(skill.name).toBe("my-branching-skill");
   });
+
+  it("infers name from .claude/skills/<name>/SKILL.md path", () => {
+    const content = `---
+description: Testing guide for Claude
+---
+
+TDD instructions.`;
+    const skill = parseSkill(content, ".claude/skills/testing/SKILL.md");
+    expect(skill.name).toBe("testing");
+    expect(skill.description).toBe("Testing guide for Claude");
+  });
+
+  it("prefers frontmatter name over claude skill directory name", () => {
+    const content = `---
+name: vscode-ext-guide
+---
+
+Content.`;
+    const skill = parseSkill(content, ".claude/skills/vscode-extensions/SKILL.md");
+    expect(skill.name).toBe("vscode-ext-guide");
+  });
 });

--- a/src/parsers/skillParser.ts
+++ b/src/parsers/skillParser.ts
@@ -2,7 +2,7 @@ import type { Skill } from "../models/skill.js";
 import { parseFrontmatter } from "./frontmatterParser.js";
 
 function inferNameFromPath(filePath: string): string {
-  // Convention 1: .github/skills/<name>/SKILL.md
+  // Convention 1: <parent>/skills/<name>/SKILL.md (Copilot + Claude)
   const parts = filePath.split("/");
   const skillMdIndex = parts.lastIndexOf("SKILL.md");
   if (skillMdIndex > 0) {


### PR DESCRIPTION
## Summary
- Discovers Claude Code skills from `.claude/skills/*/SKILL.md` following the [Agent Skills standard](https://agentskills.io)
- Adds project-level Claude agents (planner, implementer, reviewer) and skills (testing, vscode-extensions)
- Updates discovery glob, activation events, and file watchers for `.claude/skills/`

## New files
- `.claude/agents/planner.md`, `implementer.md`, `reviewer.md` — project Claude agents
- `.claude/skills/testing/SKILL.md`, `vscode-extensions/SKILL.md` — project Claude skills

## Test plan
- [x] All tests pass (`npm test`)
- [x] Build clean (`npm run build`)
- [ ] Manual: verify Claude skills appear in sidebar under Skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)