### PR TITLE
feat(copilot): probe all VS Code storage roots for session discovery

### DIFF
--- a/src/parsers/platformStorage.ts
+++ b/src/parsers/platformStorage.ts
@@ -1,0 +1,21 @@
+import * as path from "node:path";
+import * as os from "node:os";
+
+/**
+ * Return the platform-native VS Code app storage root.
+ * This is the "local" VS Code storage, which differs from the
+ * vscode-server storage used in SSH-Remote sessions.
+ */
+export function getPlatformStorageRoot(): string | null {
+  const home = os.homedir();
+  switch (process.platform) {
+    case "darwin":
+      return path.join(home, "Library", "Application Support", "Code", "User", "workspaceStorage");
+    case "linux":
+      return path.join(home, ".config", "Code", "User", "workspaceStorage");
+    case "win32":
+      return path.join(process.env.APPDATA ?? path.join(home, "AppData", "Roaming"), "Code", "User", "workspaceStorage");
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Closes #37. All strategies now run and accumulate with sessionId dedup. sessionDir complements rather than overrides. New strategy 4 probes the platform-native VS Code storage root (macOS/Linux/Windows) to find sessions across SSH-Remote and local VS Code.