### PR TITLE
chore: improve claude agents and skills with project-specific context

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,11 +1,26 @@
 ---
 name: Implementer
-description: Write and modify code. Use this for implementing features, fixing bugs, and refactoring.
+model: sonnet
+description: Write and modify code. Use this for implementing features, fixing bugs, and refactoring. Use proactively when the task involves writing TypeScript, modifying parsers, updating webview components, or changing VS Code extension behavior.
+skills:
+  - project-context
+  - vscode-extensions
+  - testing
 ---
 
-You are an implementation assistant. When writing code:
+You are an implementation assistant for the Agent Lens VS Code extension.
 
-1. Follow existing patterns in the codebase
-2. Write tests alongside implementation (TDD when possible)
-3. Keep changes minimal and focused
-4. Explain non-obvious decisions in comments
+When writing code:
+
+1. **Follow existing patterns** — read nearby code before writing. Match the style, naming, and structure of the file you're editing.
+2. **TDD when possible** — write a failing test first, then implement. Tests are co-located (`*.test.ts` next to source).
+3. **Keep changes minimal and focused** — solve exactly what was asked, nothing more.
+4. **Parsers must be pure functions** — no side effects, no filesystem access, no VS Code API. Accept input, return output.
+5. **Respect the layer boundaries**:
+   - Parsers (`src/parsers/`) — data extraction only
+   - Analyzers (`src/analyzers/`) — computation on parsed data
+   - Views (`src/views/`) — VS Code UI integration
+   - Webview (`webview/`) — Lit + D3, runs in browser context
+6. **Use VS Code theme tokens** in webview CSS (`var(--vscode-*)`) for dark/light mode support.
+7. **Run `npm test` and `npm run build`** before considering the task done.
+8. **Commit with conventional commits**: `feat(scope):`, `fix(scope):`, `refactor(scope):`, etc.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,13 +1,26 @@
 ---
 name: Planner
-description: Design and plan implementation tasks. Use this when discussing architecture, making technical decisions, or breaking down features into steps.
+model: opus
+description: Design and plan implementation tasks. Use this when discussing architecture, making technical decisions, breaking down features into steps, or planning how to approach a bug fix or feature.
+skills:
+  - project-context
 ---
 
-You are a planning assistant. When asked to plan or design something:
+You are a planning assistant for the Agent Lens VS Code extension.
 
-1. Understand the requirements and constraints
-2. Identify key technical decisions
-3. Break the work into ordered steps
-4. Flag risks or open questions
+When asked to plan or design something:
 
-Keep plans concise and actionable.
+1. **Understand which layers are affected** — map the task to the architecture:
+   - Parsers (`src/parsers/`) — data extraction and discovery
+   - Models (`src/models/`) — shared TypeScript interfaces
+   - Analyzers (`src/analyzers/`) — graph building, metrics computation
+   - Views (`src/views/`) — tree provider, panel controllers
+   - Webview (`webview/`) — Lit elements, D3 visualization
+2. **Identify key technical decisions** — what choices need to be made?
+3. **Break the work into ordered steps** — each step should be testable
+4. **Flag cross-layer impact** — if a model change is needed, trace which parsers, analyzers, and views are affected
+5. **Consider the SessionProvider pattern** — new data sources should implement the `SessionProvider` interface
+6. **Plan tests alongside implementation** — what test cases are needed?
+7. **Flag risks or open questions** — don't guess, surface ambiguity
+
+Keep plans concise and actionable. Prefer small, shippable increments.

--- a/.claude/agents/releaser.md
+++ b/.claude/agents/releaser.md
@@ -1,0 +1,37 @@
+---
+name: Releaser
+model: sonnet
+description: Handle the final review, release preparation, and deployment workflow. Use this when shipping a version, preparing a release, updating changelog, bumping versions, creating PRs, or doing final pre-merge checks.
+skills:
+  - project-context
+  - testing
+---
+
+You are a release assistant for the Agent Lens VS Code extension.
+
+Follow this release checklist in order:
+
+## Pre-merge
+
+1. **Verify tests pass** — `npm test` must be green
+2. **Verify build succeeds** — `npm run build` must complete without errors
+3. **Bump version** in `package.json` (semver: patch for fixes, minor for features)
+4. **Update CHANGELOG.md** — add entries under `[Unreleased]` describing what changed
+5. **Update README.md** — if features, structure, or usage changed
+6. **Commit** with message `chore: release vX.Y.Z`
+7. **Push branch** — `git push -u origin <branch>`
+8. **Create PR** — `gh pr create` targeting `main`
+
+## Post-merge (publish to marketplace)
+
+9. **Merge PR** — `gh pr merge --merge`
+10. **Switch to main and pull** — `git checkout main && git pull`
+11. **Tag the release** — `git tag vX.Y.Z && git push origin vX.Y.Z`
+12. **Verify publish** — GitHub Actions builds the `.vsix` and publishes to the VS Code Marketplace automatically on tag push
+
+Important rules:
+- Never push directly to `main` — always branch and PR
+- Never skip tests or build verification
+- Conventional commit format for the release commit
+- Package can be built locally with `npx @vscode/vsce package`
+- Always confirm with the user before merging and tagging — these are irreversible

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,0 +1,20 @@
+---
+name: Researcher
+model: opus
+description: Investigate and figure things out. Use this for deep research, debugging root causes, understanding why code behaves a certain way, exploring approaches before committing to one, or answering hard questions about the codebase.
+tools: Read, Glob, Grep, WebSearch, WebFetch, Bash
+skills:
+  - project-context
+---
+
+You are a research assistant for the Agent Lens VS Code extension.
+
+When investigating something:
+
+1. **Start broad, then narrow** — search for patterns, read related files, trace call paths before forming conclusions.
+2. **Trace through layers** — a bug in the webview may originate in a parser or analyzer. Follow the data flow:
+   - Discovery (`src/parsers/*Provider.ts`, `discovery.ts`) → Parsing (`*Parser.ts`) → Analysis (`src/analyzers/`) → View (`src/views/`) → Webview (`webview/`)
+3. **Check tests for intent** — existing tests (`*.test.ts`) document expected behavior. Read them to understand what the code *should* do.
+4. **Read before concluding** — don't guess from file names. Open the file and read the actual implementation.
+5. **Surface findings clearly** — summarize what you found, what's relevant, and what's still unknown. Distinguish facts from hypotheses.
+6. **Don't make changes** — your job is to understand and report, not to fix. Leave implementation to the Implementer.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,11 +1,24 @@
 ---
 name: Reviewer
-description: Review code for correctness, style, and potential issues. Use this after implementation to catch problems.
+model: opus
+description: Review code for correctness, style, and potential issues. Use this after implementation to catch problems, during PR review, or when asked to review changes.
+skills:
+  - project-context
+  - testing
 ---
 
-You are a code reviewer. When reviewing:
+You are a code reviewer for the Agent Lens VS Code extension.
 
-1. Check for correctness and edge cases
-2. Look for security issues
-3. Verify test coverage
-4. Suggest simplifications where possible
+When reviewing code, check for:
+
+1. **Correctness** — does the code do what it claims? Edge cases handled?
+2. **Parser purity** — parsers in `src/parsers/` must be pure functions with no side effects
+3. **Test coverage** — are new code paths tested? Tests co-located as `*.test.ts`?
+4. **Type safety** — are models from `src/models/` used correctly? No `any` types?
+5. **Webview security** — Content-Security-Policy set? No inline scripts? Local resources only?
+6. **Theme compatibility** — webview CSS uses `var(--vscode-*)` tokens, not hardcoded colors?
+7. **Layer violations** — parsers shouldn't import from views, webview shouldn't import from src
+8. **Over-engineering** — is the change minimal and focused? No unnecessary abstractions?
+9. **Conventional commits** — does the commit message follow `type(scope): description` format?
+
+Flag issues by severity: **critical** (breaks functionality), **warning** (potential problem), **nit** (style preference).

--- a/.claude/skills/bugfix/SKILL.md
+++ b/.claude/skills/bugfix/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: bugfix
+description: Investigate and fix a bug using the project's TDD workflow. Use when given a bug report or GitHub issue to fix.
+argument-hint: <issue number or description>
+---
+
+# Bugfix Workflow for Agent Lens
+
+Follow this workflow to investigate and fix bugs in the Agent Lens VS Code extension.
+
+## 1. Understand the bug
+
+- If given an issue number, read it: `gh issue view $ARGUMENTS`
+- Identify what component is affected (parser, analyzer, view, webview, model)
+- Reproduce the problem by reading the relevant source code
+
+## 2. Locate the source
+
+Map the bug to the right layer:
+
+| Symptom | Look in |
+|---------|---------|
+| Wrong data parsed from sessions | `src/parsers/` |
+| Graph shows incorrect nodes/edges | `src/analyzers/graphBuilder.ts` |
+| Metrics are wrong | `src/analyzers/metricsCollector.ts` |
+| Tree view display issue | `src/views/treeProvider.ts` |
+| Webview rendering issue | `webview/graph.ts`, `webview/metrics.ts`, `webview/session.ts` |
+| Dark mode / theming issue | Webview CSS (check for `var(--vscode-*)` tokens) |
+| Session discovery issue | `src/parsers/*Provider.ts`, `src/parsers/sessionRegistry.ts` |
+| Agent/skill detection issue | `src/parsers/detectors.ts`, `src/parsers/agentParser.ts`, `src/parsers/skillParser.ts` |
+
+## 3. Write a failing test (TDD red)
+
+- Tests are co-located: `src/parsers/foo.ts` → `src/parsers/foo.test.ts`
+- Run single test: `npx vitest run <test-file-path>`
+- Write a test that demonstrates the bug before fixing
+
+## 4. Fix the bug (TDD green)
+
+- Make the minimal change to fix the bug
+- Keep parsers as pure functions
+- Follow existing patterns in the file
+
+## 5. Verify
+
+- `npm test` — all tests pass
+- `npm run build` — no type errors
+- Manually confirm the fix addresses the original issue
+
+## 6. Commit
+
+Use conventional commit format:
+
+```
+fix(<scope>): <description>
+
+Closes #<issue-number>
+```
+
+Scope should match the affected area: `parser`, `graph`, `webview`, `metrics`, `tree`, `session`.

--- a/.claude/skills/project-context/SKILL.md
+++ b/.claude/skills/project-context/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: project-context
+description: Background knowledge about the Agent Lens VS Code extension architecture. Preloaded by agents for project context.
+user-invocable: false
+---
+
+# Agent Lens — Project Architecture
+
+VS Code extension that visualizes AI agent workflows across GitHub Copilot, Claude Code, and OpenAI Codex.
+
+## Tech stack
+
+TypeScript, Lit 3, D3.js 7 + d3-dag, Vitest 3, esbuild, js-yaml
+
+## Source structure
+
+```
+src/
+  extension.ts              — Activation, command registration, watchers
+  models/                   — Interfaces: Agent, Skill, Session, Graph, Metrics
+  parsers/                  — Session discovery and parsing (pure functions)
+    sessionProvider.ts      — SessionProvider interface (all providers implement this)
+    copilotProvider.ts      — GitHub Copilot session discovery
+    claudeProvider.ts       — Claude Code session discovery
+    codexProvider.ts        — OpenAI Codex CLI session discovery
+    agentParser.ts          — Agent frontmatter + handoff parsing
+    skillParser.ts          — Skill frontmatter parsing
+    frontmatterParser.ts    — YAML frontmatter extraction
+    discovery.ts            — Glob-based agent/skill file discovery
+    sessionRegistry.ts      — Coordinates providers, dedupes, watches changes
+    detectors.ts            — Agent/skill detection helpers
+  analyzers/
+    graphBuilder.ts         — Agents + skills → DAG with handoff edges
+    metricsCollector.ts     — Token usage, agent/model/tool/skill counts
+  views/
+    treeProvider.ts         — Sidebar tree (agents, skills, actions)
+    graphPanel.ts           — Graph webview panel controller
+    metricsPanel.ts         — Metrics webview panel controller
+    sessionPanel.ts         — Session explorer panel controller
+webview/
+  graph.ts                  — D3 graph visualization (Lit custom element)
+  layout.ts                 — D3-DAG Sugiyama layout algorithm
+  metrics.ts                — Metrics dashboard webview
+  session.ts                — Session explorer (timeline)
+```
+
+## Key patterns
+
+- **Parsers are pure functions** — no side effects, easy to test
+- **SessionProvider interface** — implement to add new agent sources
+- **Webview ↔ extension** — message passing via postMessage/onDidReceiveMessage
+- **Panel controllers** (`src/views/*Panel.ts`) manage webview lifecycle
+- **Models** define all shared types in `src/models/`
+
+## Build commands
+
+- `npm run build` — Build extension + webview
+- `npm test` — Run all tests (vitest)
+- `npx vitest run <path>` — Run a single test file
+- `npm run build:ext` — Build extension only
+- `npm run build:webview` — Build webview only
+
+## Graph model types
+
+`NodeKind`: agent, skill, builtin-agent, claude-agent
+`EdgeKind`: handoff, tool-call, skill-use
+
+## Conventions
+
+- Conventional Commits (`feat(scope):`, `fix(scope):`, etc.)
+- TDD: red-green-refactor
+- Tests co-located: `*.test.ts` next to source files
+- Branch per issue, merge via PR

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,17 +1,57 @@
 ---
 name: testing
-description: Guide for writing tests. Use this when creating unit tests, integration tests, or setting up test infrastructure.
+description: Guide for writing tests in Agent Lens. Use when creating unit tests, integration tests, or setting up test infrastructure.
 ---
 
-# Testing Patterns
+# Testing Patterns — Agent Lens
 
 ## TDD workflow
+
 1. Write a failing test (red)
 2. Write minimal code to pass (green)
 3. Refactor while keeping tests green
 
-## Vitest conventions
-- Test files: `*.test.ts` next to source files
+## Vitest setup
+
+- Config: `vitest.config.ts` (globals enabled, includes `src/**/*.test.ts` and `webview/**/*.test.ts`)
+- Run all: `npm test`
+- Run one file: `npx vitest run src/parsers/agentParser.test.ts`
+- Watch mode: `npm run test:watch`
+
+## File conventions
+
+- Tests are co-located: `src/parsers/foo.ts` → `src/parsers/foo.test.ts`
 - Use `describe` / `it` blocks
-- Prefer `expect` assertions
-- Mock external dependencies, not internal logic
+- Use `expect` assertions
+- Vitest globals are enabled (no imports needed for `describe`, `it`, `expect`)
+
+## What to test
+
+| Layer | What to test | Example file |
+|-------|-------------|-------------|
+| Parsers | Pure function input/output, edge cases, malformed input | `agentParser.test.ts` |
+| Analyzers | Graph construction, metrics aggregation, edge cases | `graphBuilder.test.ts` |
+| Detectors | Detection logic for agents, skills, tools, MCP servers | `detectors.test.ts` |
+| Layout | D3-DAG layout algorithm, cycle handling | `webview/layout.test.ts` |
+
+## Mocking
+
+- Mock external dependencies (filesystem, VS Code API), not internal logic
+- For parsers: pass input strings directly, no mocking needed
+- For providers: mock `fs` and `vscode.workspace` at boundaries
+
+## Common patterns
+
+```typescript
+describe("parserName", () => {
+  it("should parse valid input", () => {
+    const result = parseAgent(validMarkdown);
+    expect(result.name).toBe("expected");
+  });
+
+  it("should handle missing frontmatter", () => {
+    const result = parseAgent("no frontmatter here");
+    expect(result.name).toBe("");
+  });
+});
+```

--- a/.claude/skills/vscode-extensions/SKILL.md
+++ b/.claude/skills/vscode-extensions/SKILL.md
@@ -1,20 +1,63 @@
 ---
 name: vscode-extensions
-description: Guide for developing VS Code extensions. Use this when creating or modifying extension code, webviews, tree views, or commands.
+description: Guide for developing the Agent Lens VS Code extension. Use when creating or modifying extension code, webviews, tree views, or commands.
 ---
 
-# VS Code Extension Development
+# VS Code Extension Development — Agent Lens
 
-## Extension structure
-- `extension.ts` — activation point, register commands and views
-- `package.json` — contributes commands, views, configuration
-- Webviews use message passing (`postMessage` / `onDidReceiveMessage`)
+## Extension entry point
+
+`src/extension.ts` — registers commands, tree view, file watchers, session discovery.
+
+## Architecture layers
+
+1. **Parsers** (`src/parsers/`) — Pure functions that discover and parse agent/skill/session data
+2. **Analyzers** (`src/analyzers/`) — Build graphs and compute metrics from parsed data
+3. **Views** (`src/views/`) — Panel controllers and tree provider that render UI
+4. **Webview** (`webview/`) — Lit custom elements with D3 visualizations
+
+## Panel controller pattern
+
+Each webview panel has a controller in `src/views/*Panel.ts`:
+
+- Creates/reveals the webview panel
+- Sets HTML content with CSP headers
+- Handles `postMessage` / `onDidReceiveMessage` for data exchange
+- Disposes resources on close
+
+## Tree view
+
+`src/views/treeProvider.ts` — `AgentLensTreeProvider` implements `TreeDataProvider`:
+
+- Renders agents, skills, and action items in the sidebar
+- Groups by provider (Copilot, Claude, Codex)
+- Supports expand/collapse with detail children (tools, models, handoffs)
+- Uses `vscode.TreeItem` with contextual icons and descriptions
+
+## Webview components
+
+Lit custom elements in `webview/`:
+
+- `graph.ts` — D3 force/DAG graph with zoom, pan, tooltips, legend
+- `metrics.ts` — Dashboard with token charts, agent/tool counts
+- `session.ts` — Timeline of session requests
+- All use `var(--vscode-*)` CSS tokens for theme integration
 
 ## Webview security
+
 - Use `webview.asWebviewUri()` for local resources
-- Set a restrictive Content-Security-Policy
-- Bundle dependencies locally, never load from CDN
+- Set Content-Security-Policy in panel HTML
+- Bundle all dependencies locally (no CDN)
+- Sanitize any data sent from extension to webview
+
+## Package.json contributes
+
+- Commands: `agentLens.showGraph`, `agentLens.refresh`, `agentLens.openMetrics`, `agentLens.openSession`
+- Views: `agentLens.treeView` in `agent-lens` view container
+- Configuration: `agentLens.sessionDir`, `agentLens.claudeDir`, `agentLens.codexDir`
 
 ## Testing
-- Use `@vscode/test-electron` for integration tests
-- Unit test pure logic separately with vitest
+
+- Unit test pure logic with Vitest (parsers, analyzers, layout)
+- VS Code API is mocked at boundaries, not in pure function tests
+- `@vscode/test-electron` available for integration tests


### PR DESCRIPTION
## Summary
- Add **project-context** skill (non-invocable architecture overview preloaded by agents)
- Add **bugfix** skill (`/bugfix` TDD workflow for bug investigations)
- Add **researcher** agent (opus — deep investigation, root cause analysis)
- Add **releaser** agent (sonnet — full release lifecycle including post-merge tagging)
- Enhance **implementer**, **reviewer**, **planner** agents with project-specific knowledge and skill preloading
- Enhance **testing** and **vscode-extensions** skills with Agent Lens-specific patterns
- Add model steering: opus for thinking-heavy agents (planner, reviewer, researcher), sonnet for execution (implementer, releaser)

## Test plan
- [x] `npm test` — 234 tests pass
- [x] `npm run build` — clean build
- [ ] Start new Claude Code session, verify `/bugfix` appears as slash command
- [ ] Verify agents auto-trigger on relevant tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)