### PR TITLE
fix(tree): expand side panel categories by default

### DIFF
--- a/src/views/treeProvider.ts
+++ b/src/views/treeProvider.ts
@@ -35,7 +35,7 @@ export class AgentLensTreeProvider
       case "category": {
         const item = new vscode.TreeItem(
           element.label,
-          vscode.TreeItemCollapsibleState.Collapsed,
+          vscode.TreeItemCollapsibleState.Expanded,
         );
         item.contextValue = "category";
         return item;


### PR DESCRIPTION
## Summary
- Categories (Actions, Agents, Skills) now render expanded instead of collapsed
- Users see the full tree immediately when opening the side panel

## Test plan
- [x] `npm test` — 234 tests pass
- [x] `npm run build` — clean build
- [ ] Open Agent Lens sidebar, verify all categories are expanded by default

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)