### PR TITLE
fix(webview): use VS Code dropdown theme tokens for session selector

### DIFF
--- a/webview/metrics.ts
+++ b/webview/metrics.ts
@@ -308,9 +308,9 @@ class MetricsDashboard extends LitElement {
       color: var(--vscode-button-foreground, #fff);
     }
     .session-select {
-      background: none;
-      border: 1px solid var(--vscode-editorWidget-border, #454545);
-      color: var(--vscode-editor-foreground);
+      background: var(--vscode-dropdown-background, #3c3c3c);
+      border: 1px solid var(--vscode-dropdown-border, #454545);
+      color: var(--vscode-dropdown-foreground, var(--vscode-editor-foreground));
       padding: 4px 8px;
       border-radius: 4px;
       font-size: 12px;
@@ -319,9 +319,14 @@ class MetricsDashboard extends LitElement {
       opacity: 0.7;
       max-width: 220px;
     }
+    .session-select option {
+      background: var(--vscode-dropdown-background, #3c3c3c);
+      color: var(--vscode-dropdown-foreground, var(--vscode-editor-foreground));
+    }
     .session-select:hover, .session-select:focus {
       opacity: 1;
       outline: none;
+      border-color: var(--vscode-focusBorder, #007fd4);
     }
     .filter-toggle.inactive {
       opacity: 0.3;


### PR DESCRIPTION
## Summary
- Session selector on Metrics Dashboard now uses `--vscode-dropdown-*` theme tokens
- Dropdown options get explicit background/foreground so they render correctly in dark mode
- Focus state uses `--vscode-focusBorder` for consistency

## Test plan
- [x] `npm test` — 234 tests pass
- [x] `npm run build` — clean build
- [ ] Open Metrics Dashboard in dark mode, verify session selector dropdown is readable
- [ ] Open Metrics Dashboard in light mode, verify no regressions

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)