### PR TITLE
fix(parser): detect Claude Code skill usage from Skill tool_use blocks

### DIFF
--- a/src/parsers/claudeSessionParser.test.ts
+++ b/src/parsers/claudeSessionParser.test.ts
@@ -233,13 +233,64 @@ describe("parseClaudeSessionJsonl", () => {
     expect(session.requests[1].messageText).toBe("second question");
   });
 
-  it("sets empty skills/agent fields (Claude has no Copilot skills)", () => {
+  it("sets empty skills when no Skill tool is used", () => {
     const session = parseClaudeSessionJsonl(BASIC_SESSION, null);
     const req = session.requests[0];
 
     expect(req.customAgentName).toBeNull();
     expect(req.availableSkills).toEqual([]);
     expect(req.loadedSkills).toEqual([]);
+  });
+
+  it("detects loaded skills from Skill tool_use blocks", () => {
+    const lines = [
+      userLine("fix bug 48", "u1"),
+      assistantLine({
+        uuid: "a1",
+        parentUuid: "u1",
+        content: [
+          { type: "text", text: "Let me invoke the bugfix skill." },
+          { type: "tool_use", id: "toolu_skill_1", name: "Skill", input: { skill: "bugfix", args: "48" } },
+        ],
+      }),
+    ].join("\n");
+
+    const session = parseClaudeSessionJsonl(lines, null);
+    expect(session.requests[0].loadedSkills).toEqual(["bugfix"]);
+  });
+
+  it("detects multiple skills in a single request", () => {
+    const lines = [
+      userLine("help me test", "u1"),
+      assistantLine({
+        uuid: "a1",
+        parentUuid: "u1",
+        content: [
+          { type: "tool_use", id: "s1", name: "Skill", input: { skill: "testing" } },
+          { type: "tool_use", id: "s2", name: "Skill", input: { skill: "vscode-extensions" } },
+        ],
+      }),
+    ].join("\n");
+
+    const session = parseClaudeSessionJsonl(lines, null);
+    expect(session.requests[0].loadedSkills).toEqual(["testing", "vscode-extensions"]);
+  });
+
+  it("does not count non-Skill tool_use blocks as skills", () => {
+    const lines = [
+      userLine("read a file", "u1"),
+      assistantLine({
+        uuid: "a1",
+        parentUuid: "u1",
+        content: [
+          { type: "tool_use", id: "t1", name: "Read", input: { file_path: "/foo.ts" } },
+          { type: "tool_use", id: "t2", name: "Bash", input: { command: "ls" } },
+        ],
+      }),
+    ].join("\n");
+
+    const session = parseClaudeSessionJsonl(lines, null);
+    expect(session.requests[0].loadedSkills).toEqual([]);
   });
 
   it("sets timings to null (not available in Claude format)", () => {

--- a/src/parsers/claudeSessionParser.ts
+++ b/src/parsers/claudeSessionParser.ts
@@ -29,7 +29,7 @@ interface ContentBlock {
   text?: string;
   id?: string;
   name?: string;
-  input?: { subagent_type?: string };
+  input?: { subagent_type?: string; skill?: string };
   tool_use_id?: string;
   content?: ContentBlock[] | string;
 }
@@ -196,10 +196,14 @@ export function parseClaudeSessionJsonl(
       if (!msg) continue;
 
       const toolCalls: ToolCallInfo[] = [];
+      const loadedSkills: string[] = [];
       const blocks = Array.isArray(msg.content) ? msg.content : [];
       for (const block of blocks) {
         if (block.type === "tool_use" && block.id && block.name) {
           toolCalls.push({ id: block.id, name: block.name });
+          if (block.name === "Skill" && block.input?.skill) {
+            loadedSkills.push(block.input.skill);
+          }
         }
       }
 
@@ -227,7 +231,7 @@ export function parseClaudeSessionJsonl(
         },
         toolCalls,
         availableSkills: [],
-        loadedSkills: [],
+        loadedSkills,
       });
     }
   }
@@ -277,10 +281,14 @@ function parseSubagentContent(sub: SubagentInput): SessionRequest[] {
       if (!msg) continue;
 
       const toolCalls: ToolCallInfo[] = [];
+      const loadedSkills: string[] = [];
       const blocks = Array.isArray(msg.content) ? msg.content : [];
       for (const block of blocks) {
         if (block.type === "tool_use" && block.id && block.name) {
           toolCalls.push({ id: block.id, name: block.name });
+          if (block.name === "Skill" && block.input?.skill) {
+            loadedSkills.push(block.input.skill);
+          }
         }
       }
 
@@ -305,7 +313,7 @@ function parseSubagentContent(sub: SubagentInput): SessionRequest[] {
         },
         toolCalls,
         availableSkills: [],
-        loadedSkills: [],
+        loadedSkills,
         isSubagent: true,
       });
     }


### PR DESCRIPTION
## Summary
- Claude session parser now detects skill invocations from `Skill` tool_use blocks
- Extracts skill name from `block.input.skill` (e.g., `"bugfix"`, `"testing"`)
- Applies to both main session and subagent content parsing
- Previously hardcoded `loadedSkills: []` for all Claude sessions

## Test plan
- [x] `npm test` — 237 tests pass (3 new)
- [x] `npm run build` — clean build
- [ ] Use `/bugfix` or other skills in a Claude Code session
- [ ] Open Metrics Dashboard and verify Skill Usage shows Claude skills

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)