### PR TITLE
fix(parser,metrics): resolve subagent type, title, and skill detection issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.19] - 2026-02-28
+
+### Fixed
+- Metrics Dashboard: built-in Claude Code subagent types (Explore, Plan, general-purpose, Bash, compact) are no longer highlighted as custom agents (closes #56)
+- Session Explorer: Claude sessions now show the first user message as the title instead of raw session GUIDs; system-injected tags (`<ide_opened_file>`, etc.) are filtered out (closes #58)
+- Metrics Dashboard: skills preloaded via agent `skills:` frontmatter field are now detected from `<skill-format>` markers in subagent JSONL (closes #57)
+- Parser: `buildSubagentTypeMap` now recognises both `Task` and `Agent` tool names, fixing subagent type resolution for recent Claude Code versions (closes #54)
+
 ## [0.0.18] - 2026-02-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-lens",
   "displayName": "Agent Lens",
   "description": "Visualize your AI coding agents, skills, and handoffs as an interactive graph. Parses chat sessions to surface usage metrics.",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publisher": "Proliminal",
   "license": "MIT",
   "icon": "assets/icon_128.png",

--- a/src/analyzers/metricsCollector.test.ts
+++ b/src/analyzers/metricsCollector.test.ts
@@ -319,6 +319,109 @@ describe("collectMetrics", () => {
     expect(mainAgent?.count).toBe(1);
   });
 
+  it("does not mark built-in subagent types as custom", () => {
+    const sessions = [
+      makeSession({
+        requests: [
+          {
+            requestId: "r1",
+            timestamp: Date.now(),
+            agentId: "claude-code:subagent",
+            customAgentName: "Explore",
+            modelId: "claude-haiku-4-5",
+            messageText: "",
+            timings: { firstProgress: null, totalElapsed: null },
+            usage: { promptTokens: 100, completionTokens: 50 },
+            toolCalls: [],
+            availableSkills: [],
+            loadedSkills: [],
+            isSubagent: true,
+          },
+          {
+            requestId: "r2",
+            timestamp: Date.now(),
+            agentId: "claude-code:subagent",
+            customAgentName: "Plan",
+            modelId: "claude-opus-4-6",
+            messageText: "",
+            timings: { firstProgress: null, totalElapsed: null },
+            usage: { promptTokens: 100, completionTokens: 50 },
+            toolCalls: [],
+            availableSkills: [],
+            loadedSkills: [],
+            isSubagent: true,
+          },
+          {
+            requestId: "r3",
+            timestamp: Date.now(),
+            agentId: "claude-code:subagent",
+            customAgentName: "compact",
+            modelId: "claude-haiku-4-5",
+            messageText: "",
+            timings: { firstProgress: null, totalElapsed: null },
+            usage: { promptTokens: 100, completionTokens: 50 },
+            toolCalls: [],
+            availableSkills: [],
+            loadedSkills: [],
+            isSubagent: true,
+          },
+        ],
+      }),
+    ];
+
+    const metrics = collectMetrics(sessions, [], []);
+    const explore = metrics.agentUsage.find((a) => a.name === "Explore");
+    const plan = metrics.agentUsage.find((a) => a.name === "Plan");
+    const compact = metrics.agentUsage.find((a) => a.name === "compact");
+
+    expect(explore?.isCustom).toBeUndefined();
+    expect(plan?.isCustom).toBeUndefined();
+    expect(compact?.isCustom).toBeUndefined();
+  });
+
+  it("marks user-defined custom agents as custom", () => {
+    const sessions = [
+      makeSession({
+        requests: [
+          {
+            requestId: "r1",
+            timestamp: Date.now(),
+            agentId: "claude-code:subagent",
+            customAgentName: "my-code-reviewer",
+            modelId: "claude-opus-4-6",
+            messageText: "",
+            timings: { firstProgress: null, totalElapsed: null },
+            usage: { promptTokens: 100, completionTokens: 50 },
+            toolCalls: [],
+            availableSkills: [],
+            loadedSkills: [],
+            isSubagent: true,
+          },
+          {
+            requestId: "r2",
+            timestamp: Date.now(),
+            agentId: "github.copilot.editsAgent",
+            customAgentName: "Planner",
+            modelId: "copilot/claude-opus-4.6",
+            messageText: "plan this",
+            timings: { firstProgress: null, totalElapsed: null },
+            usage: { promptTokens: 100, completionTokens: 50 },
+            toolCalls: [],
+            availableSkills: [],
+            loadedSkills: [],
+          },
+        ],
+      }),
+    ];
+
+    const metrics = collectMetrics(sessions, [], []);
+    const reviewer = metrics.agentUsage.find((a) => a.name === "my-code-reviewer");
+    const planner = metrics.agentUsage.find((a) => a.name === "Planner");
+
+    expect(reviewer?.isCustom).toBe(true);
+    expect(planner?.isCustom).toBe(true);
+  });
+
   it("counts subagent child tool calls in tool usage", () => {
     const sessions = [
       makeSession({

--- a/src/analyzers/metricsCollector.ts
+++ b/src/analyzers/metricsCollector.ts
@@ -13,6 +13,17 @@ function countMap(map: Map<string, number>): CountEntry[] {
     .sort((a, b) => b.count - a.count);
 }
 
+/** Built-in Claude Code subagent types that should not be marked as custom */
+const BUILTIN_SUBAGENT_TYPES = new Set([
+  "Explore",
+  "Plan",
+  "general-purpose",
+  "Bash",
+  "compact",
+  "statusline-setup",
+  "claude-code-guide",
+]);
+
 function countMapWithCustom(
   map: Map<string, number>,
   customNames: Set<string>,
@@ -75,7 +86,9 @@ export function collectMetrics(
       // Agent usage — prefer custom agent name
       const agentName = req.customAgentName ?? req.agentId;
       agentCounts.set(agentName, (agentCounts.get(agentName) ?? 0) + 1);
-      if (req.customAgentName) usedAgents.add(req.customAgentName);
+      if (req.customAgentName && !BUILTIN_SUBAGENT_TYPES.has(req.customAgentName)) {
+        usedAgents.add(req.customAgentName);
+      }
 
       // Model usage
       modelCounts.set(req.modelId, (modelCounts.get(req.modelId) ?? 0) + 1);

--- a/src/parsers/claudeSessionParser.test.ts
+++ b/src/parsers/claudeSessionParser.test.ts
@@ -80,8 +80,58 @@ describe("parseClaudeSessionJsonl", () => {
     expect(session.title).toBe("My Summary");
   });
 
-  it("falls back to null title when no summary", () => {
+  it("derives title from first user message when no summary", () => {
     const session = parseClaudeSessionJsonl(BASIC_SESSION, null);
+    expect(session.title).toBe("Hello world");
+  });
+
+  it("truncates long first-message titles to 80 characters", () => {
+    const longMessage = "A".repeat(100);
+    const lines = [
+      userLine(longMessage, "u1"),
+      assistantLine({ uuid: "a1", parentUuid: "u1" }),
+    ].join("\n");
+
+    const session = parseClaudeSessionJsonl(lines, null);
+    expect(session.title).toBe("A".repeat(80) + "\u2026");
+  });
+
+  it("skips system-injected tags when deriving title", () => {
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        sessionId: "sess-1",
+        uuid: "u1",
+        parentUuid: null,
+        isSidechain: false,
+        timestamp: "2026-02-14T10:00:00.000Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "<ide_opened_file>The user opened the file /foo/bar.ts</ide_opened_file>",
+            },
+            {
+              type: "text",
+              text: "let's fix the bug in the parser",
+            },
+          ],
+        },
+      }),
+      assistantLine({ uuid: "a1", parentUuid: "u1" }),
+    ].join("\n");
+
+    const session = parseClaudeSessionJsonl(lines, null);
+    expect(session.title).toBe("let's fix the bug in the parser");
+  });
+
+  it("falls back to null title when no summary and no user messages", () => {
+    const lines = [
+      assistantLine({ uuid: "a1", parentUuid: "u1" }),
+    ].join("\n");
+
+    const session = parseClaudeSessionJsonl(lines, null);
     expect(session.title).toBeNull();
   });
 
@@ -504,6 +554,48 @@ describe("buildSubagentTypeMap", () => {
     expect(map.get("abc123")).toBe("Explore");
   });
 
+  it("extracts agentId to subagentType mapping from Agent tool calls (renamed from Task)", () => {
+    const agentToolUseLine = JSON.stringify({
+      type: "assistant",
+      sessionId: "sess-1",
+      uuid: "a1",
+      parentUuid: "u1",
+      isSidechain: false,
+      timestamp: "2026-02-14T10:00:02.000Z",
+      message: {
+        model: "claude-opus-4-6",
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "Agent",
+            input: {
+              description: "explore the code",
+              subagent_type: "Explore",
+              prompt: "find the parser files",
+            },
+          },
+        ],
+        usage: { input_tokens: 50, output_tokens: 10 },
+      },
+    });
+
+    const lines = [
+      userLine("do something", "u1"),
+      agentToolUseLine,
+      taskToolResultLine({
+        uuid: "u2",
+        parentUuid: "a1",
+        toolUseId: "toolu_1",
+        agentId: "abc123",
+      }),
+    ].join("\n");
+
+    const map = buildSubagentTypeMap(lines);
+    expect(map.get("abc123")).toBe("Explore");
+  });
+
   it("returns empty map when no Task tool calls", () => {
     const map = buildSubagentTypeMap(BASIC_SESSION);
     expect(map.size).toBe(0);
@@ -849,6 +941,67 @@ describe("subagent parsing", () => {
     expect(subReq!.usage.completionTokens).toBe(20);
     expect(subReq!.usage.cacheReadTokens).toBe(5000);
     expect(subReq!.usage.cacheCreationTokens).toBe(1000);
+  });
+
+  it("detects preloaded skills from skill-format tags in subagent user messages", () => {
+    const subContent = [
+      // Task prompt
+      JSON.stringify({
+        type: "user",
+        sessionId: "sess-1",
+        uuid: "su1",
+        parentUuid: null,
+        isSidechain: true,
+        timestamp: "2026-02-14T10:00:03.000Z",
+        message: {
+          role: "user",
+          content: "implement the feature",
+        },
+      }),
+      // Preloaded skills injected as user message
+      JSON.stringify({
+        type: "user",
+        sessionId: "sess-1",
+        uuid: "su2",
+        parentUuid: "su1",
+        isSidechain: true,
+        timestamp: "2026-02-14T10:00:03.100Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "<command-message>project-context</command-message>\n<command-name>project-context</command-name>\n<skill-format>true</skill-format>",
+            },
+            {
+              type: "text",
+              text: "Base directory for this skill: /path/.claude/skills/project-context\n\n# Agent Lens -- Project Architecture",
+            },
+            {
+              type: "text",
+              text: "<command-message>testing</command-message>\n<command-name>testing</command-name>\n<skill-format>true</skill-format>",
+            },
+            {
+              type: "text",
+              text: "Base directory for this skill: /path/.claude/skills/testing\n\n# Testing Guide",
+            },
+          ],
+        },
+      }),
+      subagentAssistantLine({
+        uuid: "sa1",
+        parentUuid: "su2",
+        agentId: "abc123",
+      }),
+    ].join("\n");
+
+    const session = parseClaudeSessionJsonl(BASIC_SESSION, null, [
+      { content: subContent, agentId: "abc123", subagentType: "Implementer" },
+    ]);
+
+    const subReq = session.requests.find((r) => r.isSubagent);
+    expect(subReq!.loadedSkills).toContain("project-context");
+    expect(subReq!.loadedSkills).toContain("testing");
   });
 
   it("handles empty subagent content gracefully", () => {

--- a/src/parsers/claudeSessionParser.ts
+++ b/src/parsers/claudeSessionParser.ts
@@ -68,7 +68,7 @@ export function buildSubagentTypeMap(content: string): Map<string, string> {
       for (const block of blocks) {
         if (
           block.type === "tool_use" &&
-          block.name === "Task" &&
+          (block.name === "Task" || block.name === "Agent") &&
           block.id &&
           block.input?.subagent_type
         ) {
@@ -155,6 +155,7 @@ export function parseClaudeSessionJsonl(
   let sessionId = "unknown";
   let firstTimestamp = 0;
   let lastUserText = "";
+  let firstUserText: string | null = null;
   const requests: SessionRequest[] = [];
 
   for (const line of lines) {
@@ -176,7 +177,7 @@ export function parseClaudeSessionJsonl(
     }
 
     // Track latest user message text
-    if (parsed.type === "user" && parsed.message?.content) {
+    if (parsed.type === "user" && !parsed.isSidechain && parsed.message?.content) {
       const content = parsed.message.content;
       if (typeof content === "string") {
         lastUserText = content;
@@ -186,6 +187,29 @@ export function parseClaudeSessionJsonl(
         );
         if (textBlocks.length > 0) {
           lastUserText = textBlocks.map((b) => b.text).join("\n");
+        }
+      }
+      if (firstUserText === null) {
+        // For title derivation, filter out system-injected text blocks
+        // (e.g. <ide_opened_file>, <ide_selection>, <system-reminder>)
+        let titleCandidate: string | undefined;
+        if (typeof content === "string") {
+          if (!content.trimStart().startsWith("<")) {
+            titleCandidate = content;
+          }
+        } else if (Array.isArray(content)) {
+          const userBlocks = content.filter(
+            (b) =>
+              b.type === "text" &&
+              b.text &&
+              !b.text.trimStart().startsWith("<"),
+          );
+          if (userBlocks.length > 0) {
+            titleCandidate = userBlocks[0].text;
+          }
+        }
+        if (titleCandidate) {
+          firstUserText = titleCandidate;
         }
       }
     }
@@ -247,14 +271,46 @@ export function parseClaudeSessionJsonl(
     requests.sort((a, b) => a.timestamp - b.timestamp);
   }
 
+  // Derive title: prefer summary from index, fall back to first user message
+  let title: string | null = summary;
+  if (!title && firstUserText) {
+    title =
+      firstUserText.length > 80
+        ? firstUserText.slice(0, 80) + "\u2026"
+        : firstUserText;
+  }
+
   return {
     sessionId,
-    title: summary,
+    title,
     creationDate: firstTimestamp,
     requests,
     source: "claude",
     provider: "claude",
   };
+}
+
+function detectPreloadedSkills(lines: ClaudeLine[]): string[] {
+  const skills: string[] = [];
+  for (const parsed of lines) {
+    if (parsed.type !== "user") continue;
+    const blocks = Array.isArray(parsed.message?.content)
+      ? parsed.message!.content
+      : [];
+    for (const block of blocks) {
+      if (
+        block.type === "text" &&
+        block.text &&
+        block.text.includes("<skill-format>true</skill-format>")
+      ) {
+        const match = block.text.match(/<command-name>(.+?)<\/command-name>/);
+        if (match) {
+          skills.push(match[1]);
+        }
+      }
+    }
+  }
+  return skills;
 }
 
 function parseSubagentContent(sub: SubagentInput): SessionRequest[] {
@@ -266,14 +322,19 @@ function parseSubagentContent(sub: SubagentInput): SessionRequest[] {
     (sub.agentId.startsWith("acompact-") ? "compact" : "subagent");
   const requests: SessionRequest[] = [];
 
+  // Parse all lines first for preloaded skill detection
+  const parsedLines: ClaudeLine[] = [];
   for (const line of lines) {
-    let parsed: ClaudeLine;
     try {
-      parsed = JSON.parse(line);
+      parsedLines.push(JSON.parse(line));
     } catch {
       continue;
     }
+  }
 
+  const preloadedSkills = detectPreloadedSkills(parsedLines);
+
+  for (const parsed of parsedLines) {
     // In subagent files, all lines have isSidechain: true
     // We still only want assistant messages
     if (parsed.type === "assistant") {
@@ -290,6 +351,11 @@ function parseSubagentContent(sub: SubagentInput): SessionRequest[] {
             loadedSkills.push(block.input.skill);
           }
         }
+      }
+
+      // Attach preloaded skills to the first assistant request
+      if (requests.length === 0 && preloadedSkills.length > 0) {
+        loadedSkills.push(...preloadedSkills);
       }
 
       requests.push({


### PR DESCRIPTION
## Summary
- **#56**: Built-in Claude Code subagent types (Explore, Plan, general-purpose, Bash, compact, statusline-setup, claude-code-guide) no longer marked as custom agents in the Metrics Dashboard
- **#58**: Claude sessions derive titles from the first user message instead of showing raw GUIDs; system-injected tags (`<ide_opened_file>`, `<ide_selection>`) are filtered out
- **#57**: Skills preloaded via agent `skills:` frontmatter field are detected from `<skill-format>` markers in subagent JSONL
- **#54**: `buildSubagentTypeMap` now matches both `Task` and `Agent` tool names, fixing subagent type resolution for recent Claude Code versions

## Test plan
- [x] 244 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Manual testing with .vsix — agent usage, skill usage, session titles verified
- [x] 7 new tests covering all four fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)